### PR TITLE
feat(ui): 完善线程交互并修复中文附件名

### DIFF
--- a/docs/kith-space/architecture-proposal.md
+++ b/docs/kith-space/architecture-proposal.md
@@ -227,6 +227,7 @@ agent-to-agent 分派继续经过统一 dispatch 收口。现有深度上限、�
 - `ChatWorkspace` 管理会话列表、Chat 和实时轨迹；业务模块不能直接操控 Chat 内部状态。
 - URL 是模块与 Chat 显隐事实来源。会话始终使用规范 `/s/:slug/channel[/<channelId>]`、`saved` 或 `showcase` 路径；`module`/`chat` 表达工作区布局，`taskScope`、`agent`/`agentTab`、`settings` 分别表达 Tasks、Agents、Settings 的模块资源（`web/src/shell/workspaceRoute.ts:65`、`:128`）。模块切换由 `workspaceLocationForModule`（`:143`）生成 query，不再生成 `/tasks`、`/agent`、`/settings` 等模块实体路径；Settings 未指定或传入旧/未知资源时统一归一为 `human`（`:138`）。
 - 切换频道或 Human-Agent DM 时保留当前 active module、Chat 显隐和该模块拥有的 resource query，同时丢弃旧会话的 `msg`/`thread` 等临时聚焦参数（`web/src/shell/workspaceRoute.ts:180`）。这样模块上下文跨会话导航保持稳定，旧消息焦点不会泄漏到新会话。
+- Thread 批量元数据同时返回单一 Human 的 `followed` 状态（`src/server/routes-api/channels.ts:121`）；Chat 将其作为受控状态传入 Thread 面板，并通过既有 `follow` / `unfollow` 接口切换（`web/src/views/Chat.tsx:580`、`:704`），关注切换与面板关闭保持为两个独立行为。
 - `MessageContextSnapshot` 在发送时固化 Space、会话、模块、Context Stack 和 focused item，adapter 再编码为各 runtime 所需格式。
 
 Home Spaces UI 只负责卡片、搜索、创建入口和同窗导航；路径规范化、`.kith` 校验、homeSpaceId 与 registry 摘要属于领域服务。规范 URL 是 Home 当前会话路径上的 `?module=spaces`；普通 Space 收到该 query 时移除它。从任意 Space 打开全局空间入口时导航到 Home Spaces，而不是创建第二壳。

--- a/docs/kith-space/architecture-proposal.md
+++ b/docs/kith-space/architecture-proposal.md
@@ -117,7 +117,7 @@ Home Space Memory 承载跨 Space 协调背景和组合计划，不替代 User M
 
 ### 4.6 Files
 
-文件和附件只使用本地磁盘服务。用户业务文件位于 Space root 的普通文件树，agent 相对文件操作与项目 skills 默认落在这里；产品状态位于 `.kith`，runtime prompt/临时状态位于 app data。项目 skills 由 Core 从 app.db registry 解析并向 Worker 传递 Space root，项目文件树隐藏 `.kith`、`.git` 与 `node_modules`。Agent 详情的记忆列表和读取则由 Core 解析所属 Space 后传递精确的 `agentMemoryDir = <space>/.kith/agents/<agentId>`，只能浏览该 Agent 的记忆目录；两类请求都拒绝路径遍历，调用方不能提交任意绝对路径。S3 driver、SDK 依赖、bucket 配置和 app 级上传目录均已删除；storage key 必须是平面文件名。`src/server/storage.ts` 接收 `spaceId`，通过 app.db registry 解析已注册 Space 的 rootPath，并只读写 `<spaceRoot>/.kith/uploads`。Public download 以附件记录的 `spaceId` 为准，agent plane 以认证 `spaceId` 为准；请求和调用方都不能用字符串路径绕过 registry。
+文件和附件只使用本地磁盘服务。用户业务文件位于 Space root 的普通文件树，agent 相对文件操作与项目 skills 默认落在这里；产品状态位于 `.kith`，runtime prompt/临时状态位于 app data。项目 skills 由 Core 从 app.db registry 解析并向 Worker 传递 Space root，项目文件树隐藏 `.kith`、`.git` 与 `node_modules`。Agent 详情的记忆列表和读取则由 Core 解析所属 Space 后传递精确的 `agentMemoryDir = <space>/.kith/agents/<agentId>`，只能浏览该 Agent 的记忆目录；两类请求都拒绝路径遍历，调用方不能提交任意绝对路径。S3 driver、SDK 依赖、bucket 配置和 app 级上传目录均已删除；storage key 必须是平面文件名。`src/server/attachments.ts` 在统一 multipart 边界按 UTF-8 解码文件名参数，确保浏览器和本机 Agent CLI 上传的非 ASCII 原名不会被 Latin-1 误解码。`src/server/storage.ts` 接收 `spaceId`，通过 app.db registry 解析已注册 Space 的 rootPath，并只读写 `<spaceRoot>/.kith/uploads`。Public download 以附件记录的 `spaceId` 为准，agent plane 以认证 `spaceId` 为准；请求和调用方都不能用字符串路径绕过 registry。
 
 ### 4.7 Home 与跨 Space 委派
 

--- a/docs/kith-space/ui-direction.md
+++ b/docs/kith-space/ui-direction.md
@@ -105,8 +105,8 @@ ChatOnly 由三张独立白色工作面板组成：
 会话列表 | 当前会话与 Composer | 实时轨迹
 ```
 
-- 会话列表包含 Channels 与 Human-Agent Direct Messages，保留未读、置顶、新建和切换行为；不提供 Human-Human DM。
-- 中间复用现有 `Chat`、Composer、Thread、附件和 @mention 能力；Agent 私聊标题区提供直达当前 Agent 详情页的入口；Thread 打开时默认与当前会话各占一半宽度，并可通过中间分割线继续拖拽调整。
+- 会话列表包含 Channels 与 Human-Agent Direct Messages，保留未读、置顶、新建和切换行为；不提供 Human-Human DM。会话抽屉、Agents 模块侧栏及 Agent 选择器中的相邻 Agent 行使用一致的轻量间距，保持列表层级清晰。
+- 中间复用现有 `Chat`、Composer、Thread、附件和 @mention 能力；Agent 私聊标题区提供直达当前 Agent 详情页的入口；Thread 打开时默认与当前会话各占一半宽度，并可通过中间分割线继续拖拽调整。Thread 标题栏以普通铃铛表示“已关注”、划线铃铛表示“未关注”，点击在两种状态间切换且不关闭 Thread；关闭仍由独立的 × 按钮负责。
 - 当前会话顶部始终复用紧凑 Chat 的“会话 / 轨迹”按钮：ChatOnly 中用于把对应侧栏直接收至 `0` 或恢复，不保留贯穿全高的收起栏；展开收起沿用模块切换的物理边界运动方式，但使用独立的响应曲线，内容随边界裁切，不做淡入淡出；Split 中仍用于打开对应抽屉。该短暂界面状态不进入 URL。
 - 实时轨迹继续展示 agent 的执行过程，Thread 与当前会话使用一致的面板背景。
 - 三区之间使用与整个工作区一致的有色间隙与圆角面板语言。

--- a/src/server/attachments.ts
+++ b/src/server/attachments.ts
@@ -36,7 +36,15 @@ export function sanitizeMimeType(declared: string): string {
 export function parseUpload(spaceId: string, req: IncomingMessage): Promise<{ fields: Record<string, string>; files: UploadedFile[] }> {
   return new Promise((resolve, reject) => {
     let bb: ReturnType<typeof Busboy>;
-    try { bb = Busboy({ headers: req.headers, limits: { fileSize: 25 * 1024 * 1024, files: 10 } }); }
+    try {
+      bb = Busboy({
+        headers: req.headers,
+        // Browsers encode non-ASCII multipart filename parameters as UTF-8 bytes.
+        // Busboy otherwise defaults these parameters to latin1, producing mojibake.
+        defParamCharset: "utf8",
+        limits: { fileSize: 25 * 1024 * 1024, files: 10 },
+      });
+    }
     catch (e) { return reject(e); }
     const fields: Record<string, string> = {};
     const files: UploadedFile[] = [];

--- a/src/server/routes-api/channels.ts
+++ b/src/server/routes-api/channels.ts
@@ -118,7 +118,7 @@ export async function handleChannels(ctx: SpaceCtx): Promise<boolean> {
       const replies = await db.select({ seq: schema.messages.seq, createdAt: schema.messages.createdAt }).from(schema.messages).where(eq(schema.messages.channelId, th.id)).orderBy(asc(schema.messages.seq));
       const myCm = await humanChannelState(spaceId, th.id);
       const unread = myCm ? await unreadRowsForMember(spaceId, myCm, humanId) : [];
-      map[th.parentMessageId!] = { threadChannelId: th.id, replyCount: replies.length, unreadCount: unread.length, lastReplyAt: replies.length ? replies[replies.length - 1]!.createdAt : null };
+      map[th.parentMessageId!] = { threadChannelId: th.id, replyCount: replies.length, unreadCount: unread.length, followed: Boolean(myCm?.threadFollowedAt), lastReplyAt: replies.length ? replies[replies.length - 1]!.createdAt : null };
     }
     return (sendJson(res, 200, map), true);
   }

--- a/test/agentListSpacing.unit.test.ts
+++ b/test/agentListSpacing.unit.test.ts
@@ -1,0 +1,13 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const chatSidebar = fs.readFileSync(new URL("../web/src/views/ChatSidebar.tsx", import.meta.url), "utf8");
+const members = fs.readFileSync(new URL("../web/src/views/Members.tsx", import.meta.url), "utf8");
+const css = fs.readFileSync(new URL("../web/src/styles.css", import.meta.url), "utf8");
+
+test("Agent rows share a small vertical gap across lists and pickers", () => {
+  assert.equal((chatSidebar.match(/agent-list-item/g) || []).length, 2);
+  assert.equal((members.match(/agent-list-item/g) || []).length, 1);
+  assert.match(css, /\.agent-list-item\+\.agent-list-item\{margin-top:4px\}/);
+});

--- a/test/attachments.unit.test.ts
+++ b/test/attachments.unit.test.ts
@@ -32,11 +32,11 @@ after(async () => {
   ]);
 });
 
-function uploadRequest(contents: string): Readable & { headers: Record<string, string> } {
+function uploadRequest(contents: string, filename = "t.txt"): Readable & { headers: Record<string, string> } {
   const boundary = "----kithTestBoundary";
   const body = Buffer.from(
     `--${boundary}\r\nContent-Disposition: form-data; name="channelId"\r\n\r\nchannel-1\r\n` +
-    `--${boundary}\r\nContent-Disposition: form-data; name="files"; filename="t.txt"\r\nContent-Type: text/plain\r\n\r\n${contents}\r\n` +
+    `--${boundary}\r\nContent-Disposition: form-data; name="files"; filename="${filename}"\r\nContent-Type: text/plain\r\n\r\n${contents}\r\n` +
     `--${boundary}--\r\n`,
   );
   const req = Readable.from([body]) as Readable & { headers: Record<string, string> };
@@ -53,6 +53,13 @@ test("parseUpload stores multipart files inside the authenticated Space", async 
   assert.equal(result.files[0]!.mimeType, "text/plain");
   assert.equal(result.files[0]!.size, Buffer.byteLength("hello-bytes"));
   assert.equal((await readObject(spaceId, result.files[0]!.storageKey)).toString(), "hello-bytes");
+});
+
+test("parseUpload preserves UTF-8 filenames sent by browsers", async () => {
+  const filename = "Loop-Engineering橙皮书-v260615.pdf";
+  const result = await parseUpload(spaceId, uploadRequest("pdf-bytes", filename) as any);
+
+  assert.equal(result.files[0]!.filename, filename);
 });
 
 test("parseUpload rejects instead of hanging when Space storage fails before consuming the stream", { timeout: 8000 }, async () => {

--- a/test/threadFollowToggle.unit.test.ts
+++ b/test/threadFollowToggle.unit.test.ts
@@ -1,0 +1,13 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const chat = fs.readFileSync(new URL("../web/src/views/Chat.tsx", import.meta.url), "utf8");
+
+test("thread follow control toggles state without closing the panel", () => {
+  assert.match(chat, /followed=\{thread\.followed\}/);
+  assert.match(chat, /onFollowChange=\{\(followed\) =>/);
+  assert.match(chat, /followed \? <Bell size=\{14\} \/> : <BellOff size=\{14\} \/>/);
+  assert.match(chat, /followed \? t\("chat\.unfollowThread"\) : t\("chat\.followThread"\)/);
+  assert.doesNotMatch(chat, /threads\/unfollow"[^\n]+onClose\(\)/);
+});

--- a/test/threadUnread.integration.ts
+++ b/test/threadUnread.integration.ts
@@ -186,6 +186,32 @@ async function main() {
   });
   check("thread metadata returns 200", threadMetadata.status === 200);
   check("own reply leaves unreadCount at zero", threadMetadata.body?.[parent.id]?.unreadCount === 0);
+  check("thread metadata reports the Human follow", threadMetadata.body?.[parent.id]?.followed === true);
+
+  const unfollow = await apiCall({
+    method: "POST",
+    path: "/api/channels/threads/unfollow",
+    body: { threadChannelId: thread.id },
+  });
+  check("unfollow thread returns 200", unfollow.status === 200);
+  const unfollowedMetadata = await apiCall({
+    method: "GET",
+    path: `/api/channels/${channelId}/threads?parentMessageIds=${parent.id}`,
+  });
+  check("thread metadata reports the removed follow", unfollowedMetadata.body?.[parent.id]?.followed === false);
+
+  const refollow = await apiCall({
+    method: "POST",
+    path: "/api/channels/threads/follow",
+    body: { threadChannelId: thread.id },
+  });
+  check("follow thread returns 200", refollow.status === 200);
+  const refollowedMetadata = await apiCall({
+    method: "GET",
+    path: `/api/channels/${channelId}/threads?parentMessageIds=${parent.id}`,
+  });
+  check("thread metadata reports the restored follow", refollowedMetadata.body?.[parent.id]?.followed === true);
+  await markThreadRead(thread.id);
 
   console.log("\n[3] the Human's own task transition is not unread");
   const task = await humanMessage(channelId, "task owned by the Human", true);

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -361,6 +361,7 @@
     "convertToTask": "Convert to task",
     "thread": "Thread",
     "markDone": "Mark done (remove from Inbox)",
+    "followThread": "Follow this thread",
     "unfollowThread": "Unfollow this thread",
     "viewInChannel": "View source message in channel",
     "unreadThreads": "{{count}} unread thread replies",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -361,6 +361,7 @@
     "convertToTask": "转为任务",
     "thread": "线程",
     "markDone": "标记完成(移出 Inbox)",
+    "followThread": "关注此线程",
     "unfollowThread": "取消关注此线程",
     "viewInChannel": "在频道中查看源消息",
     "unreadThreads": "{{count}} 条未读话题回复",

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -117,6 +117,7 @@ button{font-family:inherit}
 .item{display:flex;align-items:center;gap:9px;padding:6px 8px;border-radius:8px;color:var(--body);cursor:pointer;text-decoration:none;width:100%;border:0;background:transparent;font-size:16px;text-align:left}
 .item:hover{background:var(--surface-strong)}
 .item.active{background:var(--surface-strong);color:var(--ink)}
+.agent-list-item+.agent-list-item{margin-top:4px}
 .item .grow{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .badge{font-size:11px;background:var(--ink-2);color:var(--on-ink);border-radius:9999px;padding:0 6px;min-width:18px;text-align:center}
 .sec.sec-sub{font-size:10px;letter-spacing:.6px;margin:10px 4px 4px;color:var(--muted-soft)}

--- a/web/src/views/Chat.tsx
+++ b/web/src/views/Chat.tsx
@@ -8,7 +8,7 @@ import { PAGE_SIZE, appendWithCap, nextScrollState } from "../lib/msgPaging";
 import { AGENT_REPLY_PREVIEW_TYPE, AGENT_REPLY_STREAM_TICK_MS, absorbPersistedAgentMessagePreview, applyAgentReplyPreview, dropAgentReplyPreviewsForMessage, hasStreamingAgentReplyPreview, renderKeyForMessage, tickAgentReplyPreviews, type AgentReplyEvent, type AgentReplyPreviewMsg } from "../lib/agentReplyPreview";
 import { MessageContent } from "../messageRender.tsx";
 import { nextThreadMeta } from "../threadUnread";
-import { Smile, X, ExternalLink, CheckCircle2, MessageCircle, MoreHorizontal, Link2, Clipboard, Bookmark, CheckSquare, Circle, Play, Eye, Ban, ArrowDown, BellOff, Lock, Globe, Archive, Trash2 } from "lucide-react";
+import { Smile, X, ExternalLink, CheckCircle2, MessageCircle, MoreHorizontal, Link2, Clipboard, Bookmark, CheckSquare, Circle, Play, Eye, Ban, ArrowDown, Bell, BellOff, Lock, Globe, Archive, Trash2 } from "lucide-react";
 // Task badge per message row: icon changes with task status; color tokens from DESIGN.md (see .task-pill.st-* styles)
 const TASK_ICON: Record<string, typeof Circle> = { todo: Circle, in_progress: Play, in_review: Eye, done: CheckCircle2, closed: Ban };
 import { IconFile, IconExternalLink, IconDownload } from "../icons.tsx";
@@ -183,11 +183,11 @@ export function Chat({ embedded = false, channelIdOverride, threadOnly = false }
   const [loadError, setLoadError] = useState(false); // first fetch failed — exits the skeleton into a retryable error state
   const [sub, setSub] = useState("");
   const [showMembers, setShowMembers] = useState(false);
-  const [thread, setThread] = useState<{ channelId: string; parent: Msg } | null>(null); // currently open thread panel
+  const [thread, setThread] = useState<{ channelId: string; parent: Msg; followed: boolean } | null>(null); // currently open thread panel
   const [threadWidth, setThreadWidth] = useState<number | null>(null);
   const [chatSurfaceWidth, setChatSurfaceWidth] = useState(() => typeof window === "undefined" ? 1000 : window.innerWidth);
   const chatMainRef = useRef<HTMLElement>(null);
-  const [threadMeta, setThreadMeta] = useState<Record<string, { threadChannelId: string; replyCount: number; unreadCount?: number }>>({}); // parent message id → thread metadata (reply count, unread count)
+  const [threadMeta, setThreadMeta] = useState<Record<string, { threadChannelId: string; replyCount: number; unreadCount?: number; followed: boolean }>>({}); // parent message id → thread metadata (reply count, unread count, Human follow state)
   const [unreadThreads, setUnreadThreads] = useState<{ threadChannelId: string; parentMessageId: string; parentChannelId: string; unreadCount: number }[]>([]); // unread that lives in this channel's threads (invisible in the main timeline) → "jump to unread thread" bar
   const scrollRef = useRef<HTMLDivElement>(null);
   const atBottomRef = useRef(true); // tracks whether the scroll position is at the bottom; new messages auto-scroll only when already at the bottom, preserving history browsing
@@ -377,7 +377,7 @@ export function Chat({ embedded = false, channelIdOverride, threadOnly = false }
   }, [threadParam, msgs, hasMore]);
 
   const setTab = (t: string) => { const n = new URLSearchParams(sp); if (t === "chat") n.delete("chatTab"); else n.set("chatTab", t); setSp(n, { replace: true }); };
-  const startThread = async (m: Msg) => { if (!cur) return; const tid = threadMeta[m.id]?.threadChannelId || await openThread(cur.id, m.id); if (tid) { setThreadWidth(null); setThread({ channelId: tid, parent: m }); setThreadMeta((tm) => (tm[m.id] ? { ...tm, [m.id]: { ...tm[m.id]!, unreadCount: 0 } } : tm)); markRead(tid); } }; // opening a thread clears the unread count optimistically and marks the thread channel as read
+  const startThread = async (m: Msg) => { if (!cur) return; const meta = threadMeta[m.id]; const tid = meta?.threadChannelId || await openThread(cur.id, m.id); if (tid) { const followed = meta ? meta.followed : true; setThreadWidth(null); setThread({ channelId: tid, parent: m, followed }); setThreadMeta((tm) => (tm[m.id] ? { ...tm, [m.id]: { ...tm[m.id]!, unreadCount: 0 } } : tm)); markRead(tid); } }; // opening a new thread follows it; existing thread metadata preserves the Human's current follow state
   // "Jump to unread thread" bar: open a thread whose parent message may not be in the loaded page — fetch the parent
   // by id (it isn't on screen to pass through startThread), open the panel, mark it read, and drop it from the bar.
   const openUnreadThread = async (item: { threadChannelId: string; parentMessageId: string }) => {
@@ -386,7 +386,7 @@ export function Chat({ embedded = false, channelIdOverride, threadOnly = false }
       const parent = (await api("GET", `/api/messages/${item.parentMessageId}`))?.message as Msg | undefined;
       if (!parent) return;
       setThreadWidth(null);
-      setThread({ channelId: item.threadChannelId, parent });
+      setThread({ channelId: item.threadChannelId, parent, followed: true });
       setThreadMeta((tm) => (tm[parent.id] ? { ...tm, [parent.id]: { ...tm[parent.id]!, unreadCount: 0 } } : tm));
       markRead(item.threadChannelId);
       setUnreadThreads((list) => list.filter((th) => th.threadChannelId !== item.threadChannelId));
@@ -582,6 +582,19 @@ export function Chat({ embedded = false, channelIdOverride, threadOnly = false }
               parent={thread.parent}
               solo={threadOnly}
               style={threadOnly ? undefined : { width: threadConstraints.width, flexBasis: threadConstraints.width }}
+              followed={thread.followed}
+              onFollowChange={(followed) => {
+                setThread((current) => current ? { ...current, followed } : current);
+                setThreadMeta((current) => ({
+                  ...current,
+                  [thread.parent.id]: {
+                    threadChannelId: thread.channelId,
+                    replyCount: current[thread.parent.id]?.replyCount ?? 0,
+                    unreadCount: current[thread.parent.id]?.unreadCount,
+                    followed,
+                  },
+                }));
+              }}
               onClose={() => { setThread(null); setThreadWidth(null); }}
               onOpenAgent={openAgentProfile}
             />
@@ -688,7 +701,7 @@ function EditChannelModal({ channel, onClose, onDone, onDeleted }: { channel: an
 }
 
 // Thread panel: right-side overlay showing the parent message, its replies, and a reply composer.
-function ThreadPanel({ channelId, parent, solo = false, style, onClose, onOpenAgent }: { channelId: string; parent: Msg; solo?: boolean; style?: CSSProperties; onClose: () => void; onOpenAgent: (id: string) => void }) {
+function ThreadPanel({ channelId, parent, followed, solo = false, style, onClose, onFollowChange, onOpenAgent }: { channelId: string; parent: Msg; followed: boolean; solo?: boolean; style?: CSSProperties; onClose: () => void; onFollowChange: (followed: boolean) => void; onOpenAgent: (id: string) => void }) {
   const { t } = useTranslation();
   const { api, onEvent, subscribeChannel, attachmentUrl, me, react, agents, channels, slug } = useStore();
   const senderAvatar = (m: Msg) => resolveAvatar(m.senderType === "agent" ? agents.find((agent) => agent.id === m.senderId)?.avatarUrl : undefined, attachmentUrl);
@@ -712,6 +725,7 @@ function ThreadPanel({ channelId, parent, solo = false, style, onClose, onOpenAg
     if (type === "task") { try { const r = await api("GET", "/api/tasks/space"); const tk = (r?.tasks ?? r ?? []).find((x: any) => x.taskNumber === Number(args[0])); if (tk) navigateConversation(`/s/${slug}/channel/${tk.channelId}?msg=${tk.id}`); } catch { /* */ } }
   };
   const [msgs, setMsgs] = useState<Msg[]>([]);
+  const [followPending, setFollowPending] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
   useEffect(() => { subscribeChannel(channelId); (async () => { const d = await api("GET", `/api/messages/channel/${channelId}?limit=200`); setMsgs(d.messages || []); })(); }, [channelId]); // join the thread room so replies arrive live (openThread/startThread do not make the socket a room member on their own)
   useEffect(() => onEvent((e) => {
@@ -735,6 +749,17 @@ function ThreadPanel({ channelId, parent, solo = false, style, onClose, onOpenAg
     return () => window.clearInterval(timer);
   }, [streamingPreviewActive]);
   useEffect(() => { if (scrollRef.current) scrollRef.current.scrollTop = scrollRef.current.scrollHeight; }, [msgs]);
+  const toggleFollow = async () => {
+    if (followPending) return;
+    const next = !followed;
+    setFollowPending(true);
+    try {
+      await api("POST", `/api/channels/threads/${next ? "follow" : "unfollow"}`, { threadChannelId: channelId });
+      onFollowChange(next);
+    } finally {
+      setFollowPending(false);
+    }
+  };
   const row = (m: Msg, dateDivider?: ReactNode) => {
     if (m.senderType === "system") return <Fragment key={m.id}>{dateDivider}<div className="msg-sys" id={"m-" + m.id}>{m.content}</div></Fragment>; // system messages render as a banner with no avatar
     const ag = m.senderType === "agent" && m.senderId ? agents.find((a) => a.id === m.senderId) : undefined;
@@ -768,7 +793,7 @@ function ThreadPanel({ channelId, parent, solo = false, style, onClose, onOpenAg
     <aside className={`thread-panel${solo ? " thread-panel--solo" : ""}`} style={style}>
       <div className="thread-head"><span className="grow">{t("chat.thread")}</span>
         <button className="tp-link" title={t("chat.markDone")} onClick={async () => { await api("POST", "/api/channels/threads/done", { threadChannelId: channelId }); onClose(); }}><CheckCircle2 size={14} /></button>
-        <button className="tp-link" title={t("chat.unfollowThread")} onClick={async () => { await api("POST", "/api/channels/threads/unfollow", { threadChannelId: channelId }); onClose(); }}><BellOff size={14} /></button>
+        <button className="tp-link" title={followed ? t("chat.unfollowThread") : t("chat.followThread")} aria-label={followed ? t("chat.unfollowThread") : t("chat.followThread")} aria-pressed={followed} disabled={followPending} onClick={toggleFollow}>{followed ? <Bell size={14} /> : <BellOff size={14} />}</button>
         <button className="tp-link" onClick={() => navigateConversation(`/s/${slug}/channel/${parent.channelId}?msg=${parent.id}`)} title={t("chat.viewInChannel")}><ExternalLink size={14} /></button>
         <button className="tp-close" onClick={onClose} title={t("chat.close")}><X size={15} /></button></div>
       <div className="scroll" ref={scrollRef}>

--- a/web/src/views/ChatSidebar.tsx
+++ b/web/src/views/ChatSidebar.tsx
@@ -81,7 +81,7 @@ export function ChatSidebar({ channelIdOverride, preserveSearch = "" }: { channe
       {dms.map((c) => {
         const a = agents.find((agent) => agent.id === c.peerId);
         return (
-        <button key={c.id} className={"item" + (c.id === channelId ? " active" : "")} onClick={() => nav(withPreservedSearch(`/s/${slug}/channel/${c.id}`))}>
+        <button key={c.id} className={"item agent-list-item" + (c.id === channelId ? " active" : "")} onClick={() => nav(withPreservedSearch(`/s/${slug}/channel/${c.id}`))}>
           <Avatar seed={c.peerDisplayName || c.peerName || c.peerId || c.id} url={avFor(c.peerAvatarUrl)} size={20} /><span className="grow">{c.peerDisplayName || c.peerName || t("sidebar.unknownAgent")}</span>
           {a && <span className={"dot " + (a.activity || "offline")} role="img" aria-label={t("members.statusLabel", { status: agentStatusLabel(t, a.activity || "offline") })} title={a.activityDetail || agentStatusLabel(t, a.activity || "offline")} />}
           {!!unread[c.id] && <span className="badge">{unread[c.id]}</span>}
@@ -125,7 +125,7 @@ export function CreateChannelModal({ onCreate, onClose, prefill, submitLabel }: 
         <div className="member-pick">
           {fAgents.length > 0 && <div className="sec sec-sub">{t("common.agents")}</div>}
           {fAgents.map((a) => (
-            <button key={a.id} className={"item pickable" + (pickAgents.has(a.id) ? " picked" : "")} onClick={() => toggle(pickAgents, a.id, setPickAgents)}>
+            <button key={a.id} className={"item agent-list-item pickable" + (pickAgents.has(a.id) ? " picked" : "")} onClick={() => toggle(pickAgents, a.id, setPickAgents)}>
               <Avatar seed={a.name} url={avFor(a.avatarUrl)} size={22} /><span className="grow">{a.displayName || a.name}</span>{pickAgents.has(a.id) && <Check size={14} className="ck-mark" />}
             </button>
           ))}

--- a/web/src/views/Members.tsx
+++ b/web/src/views/Members.tsx
@@ -60,7 +60,7 @@ export function Agents({ agentIdOverride }: AgentsProps = {}) {
         </div>
         <div className="sec">{t("common.agents")} <span className="cnt">{agents.length}</span><button className="addbtn agents-create-button" title={t("members.createAgent")} onClick={() => setModal(true)}>+</button></div>
         {filteredAgents.map((a) => (
-          <button key={a.id} className={"item" + (a.id === agentId ? " active" : "")} onClick={() => openAgent(a.id)}>
+          <button key={a.id} className={"item agent-list-item" + (a.id === agentId ? " active" : "")} onClick={() => openAgent(a.id)}>
             <Avatar seed={a.name} url={avFor(a.avatarUrl)} size={20} /><span className="grow">{a.name}</span><span className={"dot " + statusOf(a)} role="img" aria-label={t("members.statusLabel", { status: agentStatusLabel(t, statusOf(a)) })} title={agentStatusLabel(t, statusOf(a))} />
           </button>
         ))}


### PR DESCRIPTION
## 变更摘要

- 完善线程关注/取消关注交互：普通铃铛表示已关注，划线铃铛表示未关注，切换时不关闭线程面板
- 为 Agent 列表、私信列表和 Agent 选择器增加统一的行间距
- 在统一 multipart 上传边界按 UTF-8 解码文件名，修复中文附件名乱码
- 补充线程关注、Agent 列表间距和 UTF-8 文件名回归测试，并同步架构/UI 文档

## 验证

- `pnpm run typecheck`
- `pnpm test --unit`
- `pnpm test --integration`
- `pnpm run web:build`
- `git diff --check github/main..HEAD`
- 浏览器验证线程关注状态切换、面板保持打开及页面控制台无错误