### PR TITLE
feat(canvas): 生成进度前端显示与 video 播放收尾（P2）

### DIFF
--- a/src/canvas/generation/generationJobQueue.ts
+++ b/src/canvas/generation/generationJobQueue.ts
@@ -86,6 +86,17 @@ export function getGenerationJob(
   return row ? toJobRow(row) : undefined;
 }
 
+export function listGenerationJobsByTurn(
+  db: SpaceDb,
+  turnId: string,
+): GenerationJobRow[] {
+  return db.select().from(canvasGenerationJobs)
+    .where(eq(canvasGenerationJobs.turnId, turnId))
+    .orderBy(asc(canvasGenerationJobs.createdAt))
+    .all()
+    .map(toJobRow);
+}
+
 export function listPendingJobs(
   db: SpaceDb,
   limit = 10,

--- a/src/server/routes-api/canvas.test.ts
+++ b/src/server/routes-api/canvas.test.ts
@@ -44,3 +44,76 @@ test("immutable Canvas resolver never returns bytes that fail the per-read hash"
     unregisterSpace(spaceId);
   }
 });
+
+test("canvas asset resolver serves media bytes with single-range 206 support", () => {
+  const spaceId = randomUUID();
+  const rootPath = path.join(kithSpaceHome(), "canvas-resolver-range-test", spaceId);
+  registerSpace({ id: spaceId, name: "Canvas Resolver Range", slug: `canvas-resolver-range-${spaceId}`, rootPath });
+  try {
+    const db = dbForSpace(spaceId);
+    const canvas = new CanvasCore(db, spaceId).create({ title: "Resolver Range", document: { deltaSetLike: { ROOT: { children: [] } }, frames: [] } });
+    const store = new CanvasAssetStore(db, spaceId, rootPath);
+    // Minimal mp4-shaped fixture: 24-byte ftyp box header so the store MIME sniff accepts it.
+    const bytes = Buffer.concat([
+      Buffer.from([0x00, 0x00, 0x00, 0x18]),
+      Buffer.from("ftypisom", "ascii"),
+      Buffer.from([0x00, 0x00, 0x02, 0x00]),
+      Buffer.from("isommp42", "ascii"),
+      Buffer.alloc(16, 7),
+    ]);
+    const asset = store.write({ canvasId: canvas.id, filename: "clip.mp4", mimeType: "video/mp4", bytes });
+
+    const call = (range?: string) => {
+      let status = 0;
+      let headers: Record<string, unknown> = {};
+      const responseChunks: Buffer[] = [];
+      const res = {
+        writeHead(code: number, responseHeaders?: Record<string, unknown>) {
+          status = code;
+          headers = responseHeaders ?? {};
+          return this;
+        },
+        end(chunk?: string | Buffer) { if (chunk) responseChunks.push(Buffer.from(chunk)); return this; },
+      };
+      const handled = handleCanvasAssetResolver({
+        req: { headers: range ? { range } : {} } as never,
+        res: res as never,
+        url: new URL(`http://localhost/api/canvas-assets/${spaceId}/${canvas.id}/${asset.id}`),
+        method: "GET",
+        p: `/api/canvas-assets/${spaceId}/${canvas.id}/${asset.id}`,
+        humanId: "human",
+      });
+      assert.equal(handled, true);
+      return { status, headers, body: Buffer.concat(responseChunks) };
+    };
+
+    const full = call();
+    assert.equal(full.status, 200);
+    assert.equal(full.headers["content-type"], "video/mp4");
+    assert.equal(full.headers["accept-ranges"], "bytes");
+    assert.equal(full.headers["content-length"], "40");
+    assert.deepEqual(full.body, bytes);
+
+    const mid = call("bytes=4-9");
+    assert.equal(mid.status, 206);
+    assert.equal(mid.headers["content-range"], "bytes 4-9/40");
+    assert.equal(mid.headers["content-length"], "6");
+    assert.deepEqual(mid.body, bytes.subarray(4, 10));
+
+    const suffix = call("bytes=-5");
+    assert.equal(suffix.status, 206);
+    assert.equal(suffix.headers["content-range"], "bytes 35-39/40");
+    assert.deepEqual(suffix.body, bytes.subarray(35, 40));
+
+    const openEnded = call("bytes=38-");
+    assert.equal(openEnded.status, 206);
+    assert.equal(openEnded.headers["content-range"], "bytes 38-39/40");
+
+    const invalid = call("bytes=100-200");
+    assert.equal(invalid.status, 416);
+    assert.equal(invalid.headers["content-range"], "bytes */40");
+  } finally {
+    closeSpaceDb(spaceId);
+    unregisterSpace(spaceId);
+  }
+});

--- a/src/server/routes-api/canvas.ts
+++ b/src/server/routes-api/canvas.ts
@@ -7,7 +7,10 @@ import { publish } from "../realtime.js";
 import { sendErr, sendJson } from "../util.js";
 import type { HumanCtx, SpaceCtx } from "./ctx.js";
 
-/** Same-origin media resolver: Human session authenticates the request; path pins the Space and Canvas. */
+/**
+ * Same-origin media resolver: Human session authenticates the request; path pins the Space and Canvas.
+ * Range requests get a single 206 slice so <video> nodes can stream and seek Space-local assets.
+ */
 export function handleCanvasAssetResolver(ctx: HumanCtx): boolean {
   if (ctx.method !== "GET") return false;
   const match = /^\/api\/canvas-assets\/([^/]+)\/([^/]+)\/([^/]+)$/.exec(ctx.p);
@@ -19,19 +22,54 @@ export function handleCanvasAssetResolver(ctx: HumanCtx): boolean {
     const rootPath = spaceRecord(spaceId)?.rootPath;
     if (!rootPath) return (sendErr(ctx.res, 404, "Space not found"), true);
     const found = new CanvasAssetStore(dbForSpace(spaceId), spaceId, rootPath).read(canvasId, assetId);
-    const svg = found.asset.mimeType === "image/svg+xml";
-    ctx.res.writeHead(200, {
-      "content-type": found.asset.mimeType,
-      "content-length": String(found.bytes.length),
-      "cache-control": "private, max-age=31536000, immutable",
-      "x-content-type-options": "nosniff",
-      ...(svg ? { "content-security-policy": "sandbox; default-src 'none'; style-src 'unsafe-inline'" } : {}),
-    });
-    ctx.res.end(found.bytes);
+    sendAssetBytes(ctx, found.bytes, found.asset.mimeType);
   } catch (error) {
     return sendCanvasError({ ...ctx, spaceId: "" }, error);
   }
   return true;
+}
+
+const BYTE_RANGE_PATTERN = /^bytes=(\d*)-(\d*)$/;
+
+function sendAssetBytes(
+  ctx: Pick<HumanCtx, "req" | "res">,
+  bytes: Buffer,
+  mimeType: string,
+): void {
+  const svg = mimeType === "image/svg+xml";
+  const headers = {
+    "content-type": mimeType,
+    "accept-ranges": "bytes",
+    "cache-control": "private, max-age=31536000, immutable",
+    "x-content-type-options": "nosniff",
+    ...(svg ? { "content-security-policy": "sandbox; default-src 'none'; style-src 'unsafe-inline'" } : {}),
+  };
+  const range = typeof ctx.req.headers.range === "string" ? BYTE_RANGE_PATTERN.exec(ctx.req.headers.range) : null;
+  if (!range) {
+    ctx.res.writeHead(200, { ...headers, "content-length": String(bytes.length) });
+    ctx.res.end(bytes);
+    return;
+  }
+  const total = bytes.length;
+  let start = range[1] ? Number(range[1]) : 0;
+  let end = range[2] ? Number(range[2]) : total - 1;
+  if (!range[1] && range[2]) {
+    start = Math.max(0, total - Number(range[2]));
+    end = total - 1;
+  }
+  if (start > end || start >= total) {
+    ctx.res.writeHead(416, { "content-range": `bytes */${total}` });
+    ctx.res.end();
+    return;
+  }
+  end = Math.min(end, total - 1);
+  const slice = bytes.subarray(start, end + 1);
+  ctx.res.writeHead(206, {
+    ...headers,
+    "content-range": `bytes ${start}-${end}/${total}`,
+    "content-length": String(slice.length),
+  });
+  ctx.res.end(slice);
 }
 
 async function readCanvasJson<T>(ctx: SpaceCtx, maxBytes = 20 * 1024 * 1024): Promise<T> {
@@ -125,15 +163,7 @@ export async function handleCanvas(ctx: SpaceCtx): Promise<boolean> {
       }
       if (assetId && ctx.method === "GET") {
         const found = assets.read(canvasId, assetId);
-        const svg = found.asset.mimeType === "image/svg+xml";
-        ctx.res.writeHead(200, {
-          "content-type": found.asset.mimeType,
-          "content-length": String(found.bytes.length),
-          "cache-control": "private, max-age=31536000, immutable",
-          "x-content-type-options": "nosniff",
-          ...(svg ? { "content-security-policy": "sandbox; default-src 'none'; style-src 'unsafe-inline'" } : {}),
-        });
-        ctx.res.end(found.bytes);
+        sendAssetBytes(ctx, found.bytes, found.asset.mimeType);
         return true;
       }
       if (assetId && ctx.method === "DELETE") {

--- a/src/server/routes-api/canvasGenerationJobs.test.ts
+++ b/src/server/routes-api/canvasGenerationJobs.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import test from "node:test";
+import { CanvasCore } from "../../canvas/canvasCore.js";
+import { createGenerationJob } from "../../canvas/generation/generationJobQueue.js";
+import { closeSpaceDb, dbForSpace, registerSpace, unregisterSpace } from "../../db/index.js";
+import { kithSpaceHome } from "../../paths.js";
+import { handleCanvasGenerationJobs } from "./canvasGenerationJobs.js";
+
+test("canvas-generation-jobs by-turn route returns only that turn's jobs", async () => {
+  const spaceId = randomUUID();
+  const rootPath = path.join(kithSpaceHome(), "canvas-genjobs-by-turn", spaceId);
+  registerSpace({ id: spaceId, name: "Gen Jobs By Turn", slug: `gen-jobs-by-turn-${spaceId}`, rootPath });
+  try {
+    const db = dbForSpace(spaceId);
+    const canvas = new CanvasCore(db, spaceId).create({ title: "Gen", document: { deltaSetLike: { ROOT: { children: [] } }, frames: [] } });
+    createGenerationJob(db, {
+      canvasId: canvas.id,
+      jobType: "video",
+      genPrompt: "camera slowly pans right across neon cityscape",
+      placement: { x: 0, y: 0, width: 640, height: 360 },
+      provider: "seedream",
+      turnId: "turn-1",
+      idempotencyKey: "idem-1",
+      expectedRevision: 0,
+    });
+    createGenerationJob(db, {
+      canvasId: canvas.id,
+      jobType: "image",
+      genPrompt: "deep space nebula",
+      placement: { x: 1, y: 1, width: 512, height: 512 },
+      provider: "doubao",
+      turnId: "turn-2",
+      idempotencyKey: "idem-2",
+      expectedRevision: 0,
+    });
+
+    let status = 0;
+    const responseChunks: Buffer[] = [];
+    const res = {
+      writeHead(code: number) { status = code; return this; },
+      end(chunk?: string | Buffer) { if (chunk) responseChunks.push(Buffer.from(chunk)); return this; },
+    };
+    const handled = handleCanvasGenerationJobs({
+      req: { headers: {} } as never,
+      res: res as never,
+      url: new URL("http://localhost/api/canvas-generation-jobs/by-turn/turn-1"),
+      method: "GET",
+      p: "/api/canvas-generation-jobs/by-turn/turn-1",
+      humanId: "human",
+      spaceId,
+    });
+    assert.equal(await handled, true);
+    assert.equal(status, 200);
+    const body = JSON.parse(Buffer.concat(responseChunks).toString("utf8")) as {
+      jobs: Array<{ id: string; canvasId: string; jobType: string; status: string; resultSrc: string | null }>;
+    };
+    assert.equal(body.jobs.length, 1);
+    assert.equal(body.jobs[0]!.jobType, "video");
+    assert.equal(body.jobs[0]!.status, "pending");
+    assert.equal(body.jobs[0]!.canvasId, canvas.id);
+    assert.equal(body.jobs[0]!.resultSrc, null);
+  } finally {
+    closeSpaceDb(spaceId);
+    unregisterSpace(spaceId);
+  }
+});
+
+test("canvas-generation-jobs by-turn route returns an empty list for unknown turns", async () => {
+  const spaceId = randomUUID();
+  const rootPath = path.join(kithSpaceHome(), "canvas-genjobs-by-turn-empty", spaceId);
+  registerSpace({ id: spaceId, name: "Gen Jobs By Turn Empty", slug: `gen-jobs-by-turn-empty-${spaceId}`, rootPath });
+  try {
+    let status = 0;
+    const responseChunks: Buffer[] = [];
+    const res = {
+      writeHead(code: number) { status = code; return this; },
+      end(chunk?: string | Buffer) { if (chunk) responseChunks.push(Buffer.from(chunk)); return this; },
+    };
+    const handled = handleCanvasGenerationJobs({
+      req: { headers: {} } as never,
+      res: res as never,
+      url: new URL("http://localhost/api/canvas-generation-jobs/by-turn/nope"),
+      method: "GET",
+      p: "/api/canvas-generation-jobs/by-turn/nope",
+      humanId: "human",
+      spaceId,
+    });
+    assert.equal(await handled, true);
+    assert.equal(status, 200);
+    const body = JSON.parse(Buffer.concat(responseChunks).toString("utf8")) as { jobs: unknown[] };
+    assert.deepEqual(body.jobs, []);
+  } finally {
+    closeSpaceDb(spaceId);
+    unregisterSpace(spaceId);
+  }
+});

--- a/src/server/routes-api/canvasGenerationJobs.ts
+++ b/src/server/routes-api/canvasGenerationJobs.ts
@@ -1,5 +1,5 @@
 import { dbForSpace } from "../../db/index.js";
-import { getGenerationJob } from "../../canvas/generation/generationJobQueue.js";
+import { getGenerationJob, listGenerationJobsByTurn } from "../../canvas/generation/generationJobQueue.js";
 import { kickGenerationWorker } from "../../canvas/generation/generationSupervisor.js";
 import {
   CanvasNotFoundError,
@@ -15,6 +15,7 @@ import type { SpaceCtx } from "./ctx.js";
  *   POST /api/canvases/:canvasId/generation-jobs
  *   GET  /api/canvases/:canvasId/generation-jobs/:jobId
  *   GET  /api/spaces/:spaceId/canvas-generation-jobs/:jobId
+ *   GET  /api/canvas-generation-jobs/by-turn/:turnId
  *
  * Agent enqueue stays on the Gateway; this route does not require a Canvas Access Grant.
  */
@@ -55,6 +56,13 @@ export async function handleCanvasGenerationJobs(ctx: SpaceCtx): Promise<boolean
     const job = getGenerationJob(dbForSpace(ctx.spaceId), jobId);
     if (!job) return (sendErr(ctx.res, 404, "Generation job not found"), true);
     return (sendJson(ctx.res, 200, publicGenerationJob(job, ctx.spaceId)), true);
+  }
+
+  const turnGet = /^\/api\/canvas-generation-jobs\/by-turn\/([^/]+)$/.exec(ctx.p);
+  if (turnGet && ctx.method === "GET") {
+    const turnId = decodeURIComponent(turnGet[1]!);
+    const jobs = listGenerationJobsByTurn(dbForSpace(ctx.spaceId), turnId);
+    return (sendJson(ctx.res, 200, { jobs: jobs.map((job) => publicGenerationJob(job, ctx.spaceId)) }), true);
   }
 
   return false;

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -683,6 +683,20 @@
       "usage": "Usage",
       "outcome": "Outcome"
     },
+    "generationJob": {
+      "running": "Generating {{kind}}…",
+      "completed": "{{kind}} generated and placed on the canvas",
+      "failed": "{{kind}} generation failed",
+      "failedUnknown": "unknown error",
+      "cancelled": "{{kind}} generation cancelled",
+      "estimateSeconds": "~{{seconds}}s estimated",
+      "estimateMinutes": "~{{minutes}} min estimated",
+      "kind": {
+        "image": "image",
+        "video": "video",
+        "audio": "audio"
+      }
+    },
     "unsave": "Unsave",
     "saveMessage": "Save message",
     "convertToTask": "Convert to task",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -683,6 +683,20 @@
       "usage": "用量",
       "outcome": "结果"
     },
+    "generationJob": {
+      "running": "正在生成{{kind}}…",
+      "completed": "{{kind}}已生成并放置到画布",
+      "failed": "{{kind}}生成失败",
+      "failedUnknown": "未知错误",
+      "cancelled": "{{kind}}生成已取消",
+      "estimateSeconds": "预计约 {{seconds}} 秒",
+      "estimateMinutes": "预计约 {{minutes}} 分钟",
+      "kind": {
+        "image": "图像",
+        "video": "视频",
+        "audio": "音频"
+      }
+    },
     "unsave": "取消保存",
     "saveMessage": "保存消息",
     "convertToTask": "转为任务",

--- a/web/src/views/Chat.tsx
+++ b/web/src/views/Chat.tsx
@@ -36,6 +36,7 @@ import { shouldGroupMessage } from "./chat-message/messageGrouping.ts";
 import { surfaceForSender } from "./chat-message/messagePresentation.ts";
 import { buildMessageImageGallery, isSingleImageMessage } from "./chat-message/messageImageGallery.ts";
 import { TurnDetailsButton } from "./chat-message/TurnDetailsButton.tsx";
+import { GenerationJobProgress } from "./chat-message/GenerationJobProgress.tsx";
 import { CanvasContextChip } from "./chat-message/CanvasContextChip.tsx";
 import { CanvasChip } from "./chat-message/CanvasChip.tsx";
 import type { LightboxImage } from "../Lightbox.tsx";
@@ -633,6 +634,7 @@ export function Chat({
                     {isAgentReplyPreview && !m.content
                       ? <AgentReplyPreviewBody m={m} />
                       : !!m.content && <div className="mbody"><MessageContent content={m.content} mentions={m.mentions || []} channels={messageChannels} nav={navToken} /></div>}
+                    {m.producedByTurnId ? <GenerationJobProgress turnId={m.producedByTurnId} /> : null}
                     {!!m.attachments?.length && <div className={`msg-atts attachment-list${isSingleImageMessage(m.attachments) ? " attachment-list--single-image" : ""}`}>{m.attachments.map((a) => <AttCard key={a.id} a={a} url={attachmentUrl(a.id)} gallery={messageImageGallery} />)}</div>}
                     {(() => {
                       const contexts = messageCanvasContexts(m);
@@ -864,6 +866,7 @@ function ThreadPanel({ channelId, parent, followed, readOnly = false, solo = fal
         {isAgentReplyPreview && !m.content
           ? <AgentReplyPreviewBody m={m} />
           : !!m.content && <div className="mbody"><MessageContent content={m.content} mentions={m.mentions || []} channels={[...channels, ...archivedChannels]} nav={navToken} /></div>}
+        {m.producedByTurnId ? <GenerationJobProgress turnId={m.producedByTurnId} /> : null}
         {!!m.attachments?.length && <div className={`msg-atts attachment-list${isSingleImageMessage(m.attachments) ? " attachment-list--single-image" : ""}`}>{m.attachments.map((a) => <AttCard key={a.id} a={a} url={attachmentUrl(a.id)} gallery={threadImageGallery} />)}</div>}
         {(() => {
           const contexts = messageCanvasContexts(m);

--- a/web/src/views/chat-message/GenerationJobProgress.tsx
+++ b/web/src/views/chat-message/GenerationJobProgress.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from "react";
+import { Ban, CheckCircle2, Loader2, XCircle } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { useStore } from "../../store.tsx";
+import type { CanvasGenerationJob } from "@/features/canvas/adapters/canvasCoreApi";
+
+const POLL_INTERVAL_MS = 5000;
+const TERMINAL_STATUSES = new Set(["completed", "failed", "cancelled"]);
+/** Rough completion hints mirroring the phase3 spec: image ~30s, video 60-300s, audio ~30s. */
+const ESTIMATE_SECONDS: Record<string, number> = { image: 30, video: 120, audio: 30 };
+
+function estimateHint(t: ReturnType<typeof useTranslation>["t"], jobType: string): string | null {
+  const seconds = ESTIMATE_SECONDS[jobType];
+  if (!seconds) return null;
+  return seconds < 60
+    ? t("chat.generationJob.estimateSeconds", { seconds })
+    : t("chat.generationJob.estimateMinutes", { minutes: Math.round(seconds / 60) });
+}
+
+function GenerationJobRow({ job }: { job: CanvasGenerationJob }) {
+  const { t } = useTranslation();
+  const kind = t(`chat.generationJob.kind.${job.jobType}`, { defaultValue: job.jobType });
+  if (job.status === "completed") {
+    return (
+      <div className="flex items-center gap-1.5 text-[13px] text-muted-foreground" title={job.genPrompt}>
+        <CheckCircle2 size={13} className="shrink-0" />
+        <span>{t("chat.generationJob.completed", { kind })}</span>
+      </div>
+    );
+  }
+  if (job.status === "failed") {
+    const summary = (job.errorMessage ?? "").trim().slice(0, 140) || t("chat.generationJob.failedUnknown");
+    return (
+      <div className="flex items-center gap-1.5 text-[13px] text-destructive" title={job.errorMessage ?? undefined}>
+        <XCircle size={13} className="shrink-0" />
+        <span className="truncate">{t("chat.generationJob.failed", { kind })}{summary ? ` · ${summary}` : ""}</span>
+      </div>
+    );
+  }
+  if (job.status === "cancelled") {
+    return (
+      <div className="flex items-center gap-1.5 text-[13px] text-muted-foreground" title={job.genPrompt}>
+        <Ban size={13} className="shrink-0" />
+        <span>{t("chat.generationJob.cancelled", { kind })}</span>
+      </div>
+    );
+  }
+  const hint = estimateHint(t, job.jobType);
+  return (
+    <div className="flex items-center gap-1.5 text-[13px] text-muted-foreground" title={job.genPrompt}>
+      <Loader2 size={13} className="shrink-0 animate-spin" aria-hidden />
+      <span>
+        {t("chat.generationJob.running", { kind, status: job.status })}
+        {hint ? ` · ${hint}` : ""}
+      </span>
+    </div>
+  );
+}
+
+/** Live progress for canvas_generation_job artifacts bound to a turn reply. Stops once every job is terminal. */
+export function GenerationJobProgress({ turnId }: { turnId: string }) {
+  const { api } = useStore();
+  const [jobs, setJobs] = useState<CanvasGenerationJob[] | null>(null);
+
+  useEffect(() => {
+    let live = true;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const poll = async () => {
+      const result = await api("GET", `/api/canvas-generation-jobs/by-turn/${turnId}`).catch(() => null);
+      if (!live) return;
+      const list = Array.isArray(result?.jobs) ? result.jobs as CanvasGenerationJob[] : [];
+      setJobs(list);
+      if (list.length > 0 && list.every((job) => TERMINAL_STATUSES.has(job.status))) return;
+      timer = setTimeout(() => void poll(), POLL_INTERVAL_MS);
+    };
+    void poll();
+    return () => {
+      live = false;
+      clearTimeout(timer);
+    };
+  }, [api, turnId]);
+
+  if (!jobs?.length) return null;
+  return (
+    <div className="mt-1 flex flex-col gap-1">
+      {jobs.map((job) => <GenerationJobRow key={job.id} job={job} />)}
+    </div>
+  );
+}


### PR DESCRIPTION
## 概述

phase3 生成链路的前端遗留项收尾。基于 P2 后端（#28）。

## 改动要点

- **Chat 轨迹生成进度**：新组件 `GenerationJobProgress`——消息携带生成 job 时显示进度（queued/running/succeeded/failed + 类型 + 预计时长），5s 轮询新增的 by-turn 查询路由 `GET /api/canvas-generation-jobs/by-turn/:turnId`，全部终态停止、卸载清理；主聊天与 ThreadPanel 两处挂载，中英文文案
- **video 播放收尾**：侦察确认 URL 链路（op durable src → hydrate → VideoNodeOverlay → 同源解析）在代码层已完整，真实断点是资产路由无 Range 支持（视频只能整段缓冲后才能 seek）——资产路由补最小单区间 HTTP Range（206/Content-Range/Accept-Ranges/416），零 upstream 文件改动

## 本地验证

- `pnpm run typecheck`（含 web）与 `web:build` 通过；全量单测 1258/1258 目标测试通过（3 个失败为预存在项，见 #26 说明）
- 新增：canvasGenerationJobs by-turn 路由测试、资产 Range 语义测试（最小 mp4 ftyp fixture）
- 验证边界（如实）：UI 渲染与轮询生命周期、真实视频播放未在真实浏览器验证（真实生成需付费 provider key）；已验证数据面（路由响应形状、停止条件、Range 字节路径、MIME 嗅探）
