### PR TITLE
feat(runtime): 内置 Pi-Agent 运行时、模型预设与本机配置导入，并向导式创建 Agent

### DIFF
--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -24,6 +24,54 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
+## @earendil-works/pi-agent-core 0.84.2
+
+MIT License
+
+Copyright (c) 2025 Mario Zechner
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+## @earendil-works/pi-coding-agent 0.84.2
+
+MIT License
+
+Copyright (c) 2025 Mario Zechner
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
 ## undici 7.28.0
 
 MIT License

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2,7 +2,7 @@
 
 ## 前言
 
-这份文档记录 Kith-space 的锁定决策。第一轮 `/grill-me` 会话发生在 2026-07-09，形成最初 19 条决策；随后包管理迁移形成决策 20。第二轮 `/grill-me` 发生在 2026-07-11，在 40 个问题内把产品正式收敛为本机、单 Human 的个人 AgentOS，并形成决策 21，推翻原先“多用户/多机器能力休眠保留”的路线。2026-07-12 的 A1-A6 用户验收进一步确认 Agent 首轮生命周期（决策 22）以及 Home 总控 Space、用户可见 Space 根目录和跨 Space 委派边界（决策 23）；随后授权浏览器的目录选择收敛为受限主机目录浏览器（决策 24）。2026-07-14 又锁定会话聚合面板（决策 25）与 Agent 频道响应模式（决策 26）；2026-07-15 在该响应机制上补充 Human 专属的频道全体提及（决策 27），并把 ChatOnly 的模块导航迁入左侧栏、模块打开态继续使用 Dock，同时退役案例展示（决策 28）。2026-07-18 本轮 UI 验收结束后，项目锁定“保留 Desktop/Core/Worker 拓扑与 TypeScript 主栈，以模块化单体渐进收敛、性能证据驱动 Rust 决策”的工程路线（决策 29）；P-A10 的 Agent Harness v2 形成决策 30，2026-07-22 至 23 又形成并修订系统 Memory Advisor Provider、模型配置和快捷安装边界（决策 31–33）；2026-07-24 新增前端统一采用 Tailwind CSS v4 + shadcn/ui 的渐进迁移决策（决策 34）。2026-08-15 又确认以 Recombyn RCB、既有 Workspace Tabs、Kith Harness 和 revisioned Canvas Module 交付 Canvas MVP（决策 38）。当前结论以每条决策中的最新修正为准。
+这份文档记录 Kith-space 的锁定决策。第一轮 `/grill-me` 会话发生在 2026-07-09，形成最初 19 条决策；随后包管理迁移形成决策 20。第二轮 `/grill-me` 发生在 2026-07-11，在 40 个问题内把产品正式收敛为本机、单 Human 的个人 AgentOS，并形成决策 21，推翻原先“多用户/多机器能力休眠保留”的路线。2026-07-12 的 A1-A6 用户验收进一步确认 Agent 首轮生命周期（决策 22）以及 Home 总控 Space、用户可见 Space 根目录和跨 Space 委派边界（决策 23）；随后授权浏览器的目录选择收敛为受限主机目录浏览器（决策 24）。2026-07-14 又锁定会话聚合面板（决策 25）与 Agent 频道响应模式（决策 26）；2026-07-15 在该响应机制上补充 Human 专属的频道全体提及（决策 27），并把 ChatOnly 的模块导航迁入左侧栏、模块打开态继续使用 Dock，同时退役案例展示（决策 28）。2026-07-18 本轮 UI 验收结束后，项目锁定“保留 Desktop/Core/Worker 拓扑与 TypeScript 主栈，以模块化单体渐进收敛、性能证据驱动 Rust 决策”的工程路线（决策 29）；P-A10 的 Agent Harness v2 形成决策 30，2026-07-22 至 23 又形成并修订系统 Memory Advisor Provider、模型配置和快捷安装边界（决策 31–33）；2026-07-24 新增前端统一采用 Tailwind CSS v4 + shadcn/ui 的渐进迁移决策（决策 34）。2026-08-15 又确认以 Recombyn RCB、既有 Workspace Tabs、Kith Harness 和 revisioned Canvas Module 交付 Canvas MVP（决策 38）。2026-09-03 用原创 eval 基线量化画布设计质量并默认开启 Canvas Agent 执行入口（决策 39–40）。2026-09-02 决定随装内置锁定版 Pi-Agent 运行时并配套模型预设、本地配置导入与首启 Agent 向导（决策 41）。当前结论以每条决策中的最新修正为准。
 
 盘问的方式是一次给一个决策、每次给一个明确建议，让用户在 either/or 之间做取舍。会话过程中有几条决策被推翻或修正过（底座、runtime、Redis 的真实用途、聊天历史随文件夹走的成本），这些演化本身是理解项目为什么长成现在这样的关键，因此单列一节保留。
 
@@ -51,6 +51,7 @@
 | 36 | 三端工程基线 | 发行保持 Windows-first，共享工程同时评估 Windows/macOS/Linux |
 | 37 | Agent 活动来源 | 活动历史持久保存来源渠道；会话聚合面板不重复显示来源 |
 | 38 | Recombyn Canvas Module | 保留 Recombyn 编辑器 UI，接入既有 Workspace Tabs 与 Kith Harness；Core revisioned command 是唯一真相源 |
+| 41 | 内置 Pi-Agent 运行时 | 随装内置锁定版 pi-agent-core/pi-coding-agent 驱动的 `pi-builtin` 运行时，复用官方 `runRpcMode` 协议；模型设置接入 Pi 官方预设与本地 Pi 配置导入；首次进入 Home 弹窗引导创建第一个 Agent |
 
 > 历史档案中“UI 字号与字重”和“三端工程基线”曾同时编号为决策 36；本轮保留原编号，避免改写既有引用。
 
@@ -609,6 +610,26 @@
 **推理与权衡**：fail-closed 默认是阶段 4 移植期的保守护栏，前提是 Canvas Agent 工具面尚未验收。P0–P2 质量对齐工作（skill 系统补全、SCENE_FACTS 事实区、design_review 评审档案、生成链路收尾）落地并经单测验证后，画布 Agent 已是核心产品能力，打包产物默认关闭会让正式安装中的整个画布 Agent 面不可用。权限边界的实质防线是 per-turn `CanvasAccessGrant`（canvas/object/action scope、revision、fail-closed 撤销），而非进程级总开关；保留环境变量作为运维/排查的紧急停用手段，语义从 opt-in 变为 opt-out。若未来出现需要按安装关闭画布 Agent 的场景，再评估升级为用户可见设置项。
 
 ---
+
+## 决策 41：内置 Pi-Agent 作为随装可用的 Agent 运行时，复用官方 RPC 协议与模型预设
+
+**状态**：Accepted（2026-09-02；实现于 `task/1`，通过 typecheck、单元测试与 helper 冒烟验证）。
+
+**结论**：Kith-space 随装内置一个由锁定版 `@earendil-works/pi-agent-core@0.84.2` + `@earendil-works/pi-coding-agent@0.84.2` SDK 驱动的 Pi Agent 运行时，runtime id 为 `pi-builtin`，用户即使本机没有任何 Agent CLI 也能直接创建 Agent。该结论部分推翻决策 31 中"否决内置完整 Pi coding agent"的取舍：当时否决的是让内置 Pi 成为普通 Agent 并放任其权限面与资源发现面；现在保留同一否决精神，以 Kith-owned helper 子进程 + 私有配置根 + 离线模型运行时 + 禁用扩展/技能/模板/主题/上下文文件的方式内置，权限面与既有外部 Pi runtime 对齐（cli_only 网关、无 sandbox、默认内置工具），资源发现与全局 `~/.pi/agent` 配置读取均不执行。
+
+**运行形态**：内置 Pi 不启动完整 CLI，而是在 Worker 侧新增 `pi-agent-helper.mjs`（打包进 `desktop/dist/runtime/`，与 `pi-advisor-helper.mjs` 同构）。helper 用 SDK 的 `ModelRuntime.create({ allowModelNetwork:false, refreshOnCreate:false })` + `createAgentSessionServices`（`noExtensions/noSkills/noPromptTemplates/noThemes/noContextFiles`，`appendSystemPrompt` 注入 Harness v2 系统提示）+ `createAgentSessionRuntime` 构建会话，随后调用官方 `runRpcMode(runtime)` 以 stdio JSONL 提供与外部 Pi CLI `--mode rpc` 完全相同的协议。这样 Worker 侧把既有 `piRpcRuntimeV2` 的协议客户端泛化为共享实现，外部 `pi` 与内置 `pi-builtin` 两个适配器只差 spawn 规格（可执行文件 + 参数 + env），会话恢复（session-dir + session-id）、usage、compaction、cancel、`agent_settled` 等基线能力天然一致。`@earendil-works/pi-coding-agent` 只进入 helper bundle，不进 Worker/Advisor bundle，Advisor 的 `pi-agent-core/pi-coding-agent/compat` 禁用校验保持不变。
+
+**配置与凭据边界**：新增 `PiBuiltinRuntimeConfigCompiler`（runtimeId `pi-builtin`），沿用 Pi 编译器的私有根模式：每会话在 `runtimeStateDir` 下生成 0o700 私有根，写入 `models.json`（`kith` provider：`baseUrl`/`api`/`apiKey: "$KITH_PI_API_KEY"`/模型）与 `settings.json`（`defaultProjectTrust: "never"`），env 注入 `PI_CODING_AGENT_DIR=<私有根>`、`PI_CODING_AGENT_SESSION_DIR`、`KITH_PI_API_KEY`（Worker 经既有 credential redemption 兑换的单次激活值）、`PI_OFFLINE=1`、`PI_TELEMETRY=0`、`DO_NOT_TRACK=1`。helper 的 `authPath`/`modelsPath`/`sessionDir` 全部指向私有根，不读取用户 `~/.pi/agent` 的 auth/models/settings，不执行 OAuth 刷新、`!command` 值解析与模型目录网络刷新；运行时目录由既有 compiled cleanup 回收。`pi-builtin` 与 `pi` 一样如实标记 `mcp: none`、`toolIsolation: none`，通过 Kith CLI Gateway 提供产品能力。
+
+**模型配置器与官方预设**：设置页的"添加模型供应商"弹窗新增"Pi 预设"入口，数据来自 `src/advisor-provider/piSdkCatalog.ts` 的 `listPiSdkCatalog()`（同一锁定版 pi-ai 的官方 provider 目录：openai 的 openai-responses、anthropic 的 anthropic-messages、deepseek/openrouter/groq/xai 等的 openai-completions，以及 google、mistral 等），选择预设即预填 backendId/apiKind/canonicalOrigin 与官方模型清单（含 thinking levels）。新增 `piConfigModelImportService` 复用 `VerifiedConfigFileReader` 与 `PiCliConfigImporter` 的安全边界（拒绝 symlink/超限/`!command`/复合 env 插值/危险 env 名），把本机 `~/.pi/agent/models.json` 的 provider/模型导入为 Kith 供应商连接 + 模型配置；凭据优先级为 auth.json 中选中的 api_key/未过期 oauth access（`pi_cli_auth`）、models.json 字面 apiKey（Desktop 下存为 `kith_secret` 并告警）、`$VAR` 环境引用（Desktop 进程环境可解析时冻结为 `kith_secret`，否则 `keyless_local` 并提示补录）。preview/apply 采用既有 CLI import 的 source digest 防漂移模式，apply 在单事务内聚合提交。导入只读、脱敏快照、不写回任何 Pi CLI 配置。
+
+**首启向导**：`app.db` v8 在 `installation_state` 增加 `agent_onboarding_completed_at`（NULL 表示未完成）。首次进入 Home 后（而非 setup 页内），应用以弹窗形式引导创建第一个 Agent：步骤 1 选择运行时（内置 Pi-Agent 置顶并恒为可用，其后列本机已安装的 Claude Code/Codex/OpenCode/Pi 等）；步骤 2 配置模型（Pi 官方预设 / 导入本地 Pi 配置 / 手动填写，三者最终都落为 Kith 模型供应商+配置）；步骤 3 填写 Agent 名称与职责并走既有 `POST /api/agents` 创建（model binding 沿用 `runtime_default`/`pinned` 语义）。用户跳过或完成后写 `agent_onboarding_completed_at` 不再弹出；向导同时可用在模型设置与 Agent 创建弹窗中复用。
+
+**模型绑定与目录**：`pi-builtin` 进入 `RUNTIME_CATALOG`（`alwaysAvailable: true`，Worker 检测 helper 可解析即上报 installed）、`RUNTIME_V2_CAPABILITY_MATRIX`（与 `pi` 同基线）、`modelConfigurationService.SUPPORTED`（与 `pi` 相同 wire api 集合）、`turnScheduler` v2 判定与 `runtimeSessionPreparation` 的 cli_only 网关特判；`runtimeSetupCatalog` 的安装/卸载集合不含 `pi-builtin`（内置无需安装），运行器设置页仅展示"内置"状态。
+
+**推理与权衡**：用户选择 Pi-Agent 的动机是"没有 Claude/Codex 也能用"——即安装即用与低配置成本。官方 RPC 模式文档明确支持把 `AgentSession` 嵌进应用；复用 `runRpcMode` 而非自造协议，把兼容风险从"复刻一个不断演进的协议"降为"锁定版本内两条路径共用同一实现"。代价是 helper bundle 显著增大（引入 coding-agent 依赖树）且 Pi 无内置 sandbox——前者只影响安装包体积，后者与既有外部 Pi runtime 权限面一致并已如实标记，不引入新的信任边界。预设与导入复用官方 provider 目录与既有 Pi CLI import 安全解析器，避免自维护第三方模型清单。
+
+**已核实源码事实**：`src/local-runtime/runtimeCatalog.ts:1`（目录）、`src/runtime/adapters/piRpcRuntimeV2.ts:1`（外部 Pi RPC 协议客户端）、`src/runtime/config/runtimeCompilers.ts:98`（Pi 编译器）、`src/advisor-provider/piSdkCatalog.ts:20`（官方预设目录）、`src/advisor-provider/piCliConfigImporter.ts:106`（Pi CLI 配置导入）、`src/runtime/worker/maintenance/pi-advisor-helper.ts:1`（helper 同构模式）、`scripts/build-desktop.mjs:67`（helper 打包）、`src/server/routes-api/setup.ts:12`（首启 API）、`web/src/personalSetupBoundary.tsx:22`（首启门控）、`src/app-data/appDatabaseMigrations.ts:712`（installation_state 演进）。
 
 ## 尚未决定 / 刻意留白
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -135,6 +135,9 @@
 **Pi Agent Runtime**
 : 对本机外部 Pi CLI 的正式 P-A10 v2 runtime 适配器。它以RPC模式维护per-surface session，接入durable turn、Context Envelope、Kith CLI Gateway、usage、cancel、snapshot和compaction telemetry；默认禁用项目/用户extension、skill、prompt、theme和context资源，MCP诚实标为unsupported。它与内置Pi SDK Memory Advisor是两条独立路径。
 
+**Pi Agent Runtime（内置） / Built-in Pi Agent Runtime**
+: runtime id `pi-builtin`。随应用内置、由锁定版 `@earendil-works/pi-agent-core` 与 `@earendil-works/pi-coding-agent` 驱动的 Pi Agent 运行时：Worker 以 `pi-agent-helper.mjs`（打包进 `desktop/dist/runtime/` 的官方 CLI 入口）子进程方式启动会话，复用与外部 Pi CLI 相同的 JSONL RPC 协议；每会话私有配置根（`PI_CODING_AGENT_DIR` 指向 `runtimeStateDir` 下的 0o700 目录）、离线模型运行时、禁用 extension/skill/prompt/theme/context 资源，无需本机安装任何 Agent CLI。模型供应商预设与本地 Pi 配置导入均以官方 provider 目录与既有 Pi CLI import 安全边界为准。
+
 **交流表面 / Surface**
 : Agent 一段局部对话所属的稳定产品对象，当前聊天类表面为公开频道、私有频道、Human-Agent DM 和话题。P-A10已以surface隔离runtime session；任务沿用其owning thread，不另造聊天表面。automation只保留未来类型，必须等对应事实源/cursor/ACL另立契约。
 

--- a/package.json
+++ b/package.json
@@ -128,7 +128,9 @@
     }
   },
   "dependencies": {
+    "@earendil-works/pi-agent-core": "0.84.2",
     "@earendil-works/pi-ai": "0.84.2",
+    "@earendil-works/pi-coding-agent": "0.84.2",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "better-sqlite3": "^12.11.1",
     "busboy": "^1.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,13 @@ importers:
 
   .:
     dependencies:
+      '@earendil-works/pi-agent-core':
+        specifier: 0.84.2
+        version: 0.84.2(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(ws@8.21.0)(zod@3.25.76)
       '@earendil-works/pi-ai':
+        specifier: 0.84.2
+        version: 0.84.2(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(ws@8.21.0)(zod@3.25.76)
+      '@earendil-works/pi-coding-agent':
         specifier: 0.84.2
         version: 0.84.2(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(ws@8.21.0)(zod@3.25.76)
       '@modelcontextprotocol/sdk':
@@ -827,13 +833,34 @@ packages:
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
 
+  '@earendil-works/pi-agent-core@0.84.2':
+    resolution: {integrity: sha512-8Pn3wSCxj0cfo5I6jxQYVB/3uuQRmHhAlEclyjqpOuMEdQMIODHizRogv56FLdbU+dTiGnybeHQ2N+sV1/L2YA==}
+    engines: {node: '>=22.19.0'}
+
   '@earendil-works/pi-ai@0.84.2':
     resolution: {integrity: sha512-6MzsrYIYNVlE7SfpbL2yYb67Qo58p/7Q+xWG1RZvoX1P80aRCHSod2/13aFpxkow1lPO2LEh3c495J0Gwmyjig==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
+  '@earendil-works/pi-client@0.84.4':
+    resolution: {integrity: sha512-q398WY/3ZQHTizk7IKxApzqFV0xt4yM9LkSkwyqeLK5Bj5RwRjOWxESt26z4LgNp4O+8hqhqFPf/8fj4H5rE4A==}
+    engines: {node: '>=22.19.0'}
+
+  '@earendil-works/pi-coding-agent@0.84.2':
+    resolution: {integrity: sha512-l4E+B7hgXKWddRo8bC/eSue2aWZjEgJ9xIpf5p0Og+lq8a2TArCwJ0HCoCPCgaBP/tN4zbYH/wOwvx9pJpeLCA==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@earendil-works/pi-protocol@0.84.4':
+    resolution: {integrity: sha512-acyE9ozxkMiWiz/xyWpU0O9vwnYv0hyG889Vniv6Sg9c9zfsX+8MePnDNphBacY2Fvm1rxdsGmiVDSZl9yuDFA==}
+    engines: {node: '>=22.19.0'}
+
   '@earendil-works/pi-telemetry@0.84.2':
     resolution: {integrity: sha512-wg5caea7uIv1BHRBm2Y116RvFG4oSAiP5qk9tA2463PDGIr4K8M1Ceyyg5DOpF/shUUl0gk826yQJAeAcHYB9g==}
+    engines: {node: '>=22.19.0'}
+
+  '@earendil-works/pi-tui@0.84.4':
+    resolution: {integrity: sha512-nPUnwDkLtupPXnZQYrCwPFcuTydCDqTY6ZbFqhsL4S4kVq0AT418kPa/6uXwtaCD+MjBNBltb7ScTYX65yeE1w==}
     engines: {node: '>=22.19.0'}
 
   '@electron-internal/extract-zip@1.0.4':
@@ -1456,6 +1483,74 @@ packages:
   '@malept/flatpak-bundler@0.4.0':
     resolution: {integrity: sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==}
     engines: {node: '>= 10.0.0'}
+
+  '@mariozechner/clipboard-darwin-arm64@0.3.9':
+    resolution: {integrity: sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@mariozechner/clipboard-darwin-universal@0.3.9':
+    resolution: {integrity: sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==}
+    engines: {node: '>= 10'}
+    os: [darwin]
+
+  '@mariozechner/clipboard-darwin-x64@0.3.9':
+    resolution: {integrity: sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@mariozechner/clipboard-linux-arm64-gnu@0.3.9':
+    resolution: {integrity: sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@mariozechner/clipboard-linux-arm64-musl@0.3.9':
+    resolution: {integrity: sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.9':
+    resolution: {integrity: sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@mariozechner/clipboard-linux-x64-gnu@0.3.9':
+    resolution: {integrity: sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@mariozechner/clipboard-linux-x64-musl@0.3.9':
+    resolution: {integrity: sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@mariozechner/clipboard-win32-arm64-msvc@0.3.9':
+    resolution: {integrity: sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@mariozechner/clipboard-win32-x64-msvc@0.3.9':
+    resolution: {integrity: sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@mariozechner/clipboard@0.3.9':
+    resolution: {integrity: sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA==}
+    engines: {node: '>= 10'}
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -2430,6 +2525,9 @@ packages:
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
+  '@silvia-odwyer/photon-node@0.3.4':
+    resolution: {integrity: sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==}
+
   '@sindresorhus/is@4.6.0':
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
@@ -2736,6 +2834,7 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   abbrev@4.0.0:
     resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
@@ -3756,6 +3855,10 @@ packages:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
 
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
@@ -3786,6 +3889,10 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  grok-mermaid@0.2.2:
+    resolution: {integrity: sha512-XcJEP5dDC8liHBh52mlLjU18fNvu1ckFsu0QpIG3+APZ270fsj9wxpiA6cOURmbUEuoMVgjbC2+UYgTdCqqgzA==}
+    engines: {node: '>=18'}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -3855,6 +3962,9 @@ packages:
     resolution: {integrity: sha512-Qgpiaws3Sm30Av8Eah6sjMCZZwjlBu+E68rhpCWBshY1lb09HtLwj5GviX0OyQIn+ulUS0iX0AxN5n3tLZzz1w==}
     engines: {node: '>=18.0.0'}
 
+  highlight.js@10.7.3:
+    resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
+
   hono@4.12.28:
     resolution: {integrity: sha512-YwUvVpSF7m1yOblFPrU3Hbo8XhPheBoiyfGuII6z19LnOr6JpDnyyp7LFNrfV56wS8tpvtBFGRISHN02pDdLOA==}
     engines: {node: '>=16.9.0'}
@@ -3862,6 +3972,10 @@ packages:
   hosted-git-info@4.1.0:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
     engines: {node: '>=10'}
+
+  hosted-git-info@9.0.3:
+    resolution: {integrity: sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   html-parse-stringify@3.0.1:
     resolution: {integrity: sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==}
@@ -3919,6 +4033,10 @@ packages:
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
   immer@11.1.16:
@@ -4263,6 +4381,10 @@ packages:
     resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
     engines: {node: '>=8'}
 
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -4280,6 +4402,11 @@ packages:
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  marked@18.0.5:
+    resolution: {integrity: sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==}
+    engines: {node: '>= 20'}
+    hasBin: true
 
   matcher@3.0.0:
     resolution: {integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==}
@@ -4725,6 +4852,10 @@ packages:
   path-key@4.0.0:
     resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
     engines: {node: '>=12'}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
@@ -5201,6 +5332,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.8.0:
+    resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
@@ -5525,6 +5661,10 @@ packages:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
+  undici@8.9.0:
+    resolution: {integrity: sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==}
+    engines: {node: '>=22.19.0'}
+
   unicode-properties@1.4.1:
     resolution: {integrity: sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==}
 
@@ -5772,6 +5912,11 @@ packages:
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
 
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
@@ -6525,6 +6670,22 @@ snapshots:
 
   '@drizzle-team/brocli@0.10.2': {}
 
+  '@earendil-works/pi-agent-core@0.84.2(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(ws@8.21.0)(zod@3.25.76)':
+    dependencies:
+      '@earendil-works/pi-ai': 0.84.2(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(ws@8.21.0)(zod@3.25.76)
+      '@earendil-works/pi-telemetry': 0.84.2
+      diff: 8.0.4
+      ignore: 7.0.5
+      typebox: 1.3.7
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
   '@earendil-works/pi-ai@0.84.2(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(ws@8.21.0)(zod@3.25.76)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@3.25.76)
@@ -6546,7 +6707,53 @@ snapshots:
       - ws
       - zod
 
+  '@earendil-works/pi-client@0.84.4':
+    dependencies:
+      '@earendil-works/pi-protocol': 0.84.4
+
+  '@earendil-works/pi-coding-agent@0.84.2(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(ws@8.21.0)(zod@3.25.76)':
+    dependencies:
+      '@earendil-works/pi-agent-core': 0.84.2(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(ws@8.21.0)(zod@3.25.76)
+      '@earendil-works/pi-ai': 0.84.2(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(ws@8.21.0)(zod@3.25.76)
+      '@earendil-works/pi-client': 0.84.4
+      '@earendil-works/pi-protocol': 0.84.4
+      '@earendil-works/pi-tui': 0.84.4
+      '@silvia-odwyer/photon-node': 0.3.4
+      chalk: 5.6.2
+      cross-spawn: 7.0.6
+      diff: 8.0.4
+      glob: 13.0.6
+      grok-mermaid: 0.2.2
+      highlight.js: 10.7.3
+      hosted-git-info: 9.0.3
+      ignore: 7.0.5
+      jiti: 2.7.0
+      minimatch: 10.2.5
+      proper-lockfile: 4.1.2
+      semver: 7.8.0
+      typebox: 1.3.7
+      undici: 8.9.0
+      yaml: 2.9.0
+    optionalDependencies:
+      '@mariozechner/clipboard': 0.3.9
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-protocol@0.84.4':
+    dependencies:
+      typebox: 1.3.7
+
   '@earendil-works/pi-telemetry@0.84.2': {}
+
+  '@earendil-works/pi-tui@0.84.4':
+    dependencies:
+      get-east-asian-width: 1.6.0
+      marked: 18.0.5
 
   '@electron-internal/extract-zip@1.0.4': {}
 
@@ -7006,6 +7213,50 @@ snapshots:
       tmp-promise: 3.0.3
     transitivePeerDependencies:
       - supports-color
+
+  '@mariozechner/clipboard-darwin-arm64@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-darwin-universal@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-darwin-x64@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-linux-arm64-gnu@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-linux-arm64-musl@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-linux-x64-gnu@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-linux-x64-musl@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-win32-arm64-msvc@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-win32-x64-msvc@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard@0.3.9':
+    optionalDependencies:
+      '@mariozechner/clipboard-darwin-arm64': 0.3.9
+      '@mariozechner/clipboard-darwin-universal': 0.3.9
+      '@mariozechner/clipboard-darwin-x64': 0.3.9
+      '@mariozechner/clipboard-linux-arm64-gnu': 0.3.9
+      '@mariozechner/clipboard-linux-arm64-musl': 0.3.9
+      '@mariozechner/clipboard-linux-riscv64-gnu': 0.3.9
+      '@mariozechner/clipboard-linux-x64-gnu': 0.3.9
+      '@mariozechner/clipboard-linux-x64-musl': 0.3.9
+      '@mariozechner/clipboard-win32-arm64-msvc': 0.3.9
+      '@mariozechner/clipboard-win32-x64-msvc': 0.3.9
+    optional: true
 
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
@@ -8011,6 +8262,8 @@ snapshots:
     optional: true
 
   '@sec-ant/readable-stream@0.4.1': {}
+
+  '@silvia-odwyer/photon-node@0.3.4': {}
 
   '@sindresorhus/is@4.6.0': {}
 
@@ -9444,6 +9697,12 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
   glob@7.2.3:
     dependencies:
       fs.realpath: 1.0.0
@@ -9499,6 +9758,8 @@ snapshots:
       responselike: 2.0.1
 
   graceful-fs@4.2.11: {}
+
+  grok-mermaid@0.2.2: {}
 
   has-flag@4.0.0: {}
 
@@ -9655,11 +9916,17 @@ snapshots:
 
   helmet@8.3.0: {}
 
+  highlight.js@10.7.3: {}
+
   hono@4.12.28: {}
 
   hosted-git-info@4.1.0:
     dependencies:
       lru-cache: 6.0.0
+
+  hosted-git-info@9.0.3:
+    dependencies:
+      lru-cache: 11.5.2
 
   html-parse-stringify@3.0.1:
     dependencies:
@@ -9717,6 +9984,8 @@ snapshots:
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
+
+  ignore@7.0.5: {}
 
   immer@11.1.16: {}
 
@@ -9967,6 +10236,8 @@ snapshots:
 
   lowercase-keys@2.0.0: {}
 
+  lru-cache@11.5.2: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -9984,6 +10255,8 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   markdown-table@3.0.4: {}
+
+  marked@18.0.5: {}
 
   matcher@3.0.0:
     dependencies:
@@ -10602,6 +10875,11 @@ snapshots:
   path-key@3.1.1: {}
 
   path-key@4.0.0: {}
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.5.2
+      minipass: 7.1.3
 
   path-to-regexp@8.4.2: {}
 
@@ -11239,6 +11517,8 @@ snapshots:
 
   semver@7.7.4: {}
 
+  semver@7.8.0: {}
+
   semver@7.8.5: {}
 
   send@1.2.1:
@@ -11631,6 +11911,8 @@ snapshots:
 
   undici@7.28.0: {}
 
+  undici@8.9.0: {}
+
   unicode-properties@1.4.1:
     dependencies:
       base64-js: 1.5.1
@@ -11841,6 +12123,8 @@ snapshots:
   yallist@4.0.0: {}
 
   yallist@5.0.0: {}
+
+  yaml@2.9.0: {}
 
   yargs-parser@21.1.1: {}
 

--- a/scripts/build-desktop.mjs
+++ b/scripts/build-desktop.mjs
@@ -1,6 +1,7 @@
 import { build } from "esbuild";
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
+import os from "node:os";
 import { fileURLToPath } from "node:url";
 import { createHash } from "node:crypto";
 import { spawn } from "node:child_process";
@@ -94,6 +95,104 @@ desktopBuilds.push(helperBuild.then(async (result) => {
     thirdPartyLicensesSha256: createHash("sha256").update(licenseBytes).digest("hex"),
     inputs: inputs.sort(),
     forbiddenDependencies: [],
+  }, null, 2));
+}));
+
+async function verifyPiAgentHelperStartup(helperPath, assetsDir) {
+  const piAgentRoot = await mkdtemp(path.join(os.tmpdir(), "kith-pi-agent-smoke-"));
+  try {
+    await mkdir(path.join(piAgentRoot, "agent"), { recursive: true });
+    await mkdir(path.join(piAgentRoot, "sessions"), { recursive: true });
+    await writeFile(path.join(piAgentRoot, "agent", "models.json"), JSON.stringify({
+      providers: { kith: { baseUrl: "https://api.deepseek.com", apiKey: "$KITH_PI_API_KEY", api: "openai-completions",
+        models: [{ id: "smoke-model", name: "smoke-model" }] } },
+    }));
+    await writeFile(path.join(piAgentRoot, "agent", "settings.json"), JSON.stringify({ defaultProjectTrust: "never" }));
+    await new Promise((resolve, reject) => {
+      const child = spawn(process.execPath, [helperPath,
+        "--mode", "rpc", "--provider", "kith", "--model", "smoke-model",
+        "--no-approve", "--no-context-files", "--no-extensions", "--no-skills",
+        "--no-prompt-templates", "--no-themes", "--session-dir", path.join(piAgentRoot, "sessions"),
+      ], {
+        cwd: piAgentRoot,
+        env: {
+          PI_PACKAGE_DIR: assetsDir,
+          PI_CODING_AGENT_DIR: path.join(piAgentRoot, "agent"),
+          PI_CODING_AGENT_SESSION_DIR: path.join(piAgentRoot, "sessions"),
+          KITH_PI_API_KEY: "smoke-key", PI_OFFLINE: "1", PI_TELEMETRY: "0", DO_NOT_TRACK: "1",
+          FORCE_COLOR: "0",
+        },
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      let stdout = "";
+      let stderrBytes = 0;
+      const timer = setTimeout(() => { child.kill(); reject(new Error("Pi Agent helper startup smoke test timed out")); }, 30_000);
+      child.stdout.on("data", (chunk) => { stdout += chunk; });
+      child.stderr.on("data", (chunk) => { stderrBytes += chunk.length; });
+      child.on("error", (error) => { clearTimeout(timer); reject(error); });
+      child.on("exit", (code) => {
+        clearTimeout(timer);
+        try {
+          const response = JSON.parse(stdout);
+          if (code !== 0 || response?.type !== "response" || response.command !== "get_state"
+            || response.success !== true || typeof response.data?.sessionId !== "string" || stderrBytes !== 0) {
+            throw new Error(`unexpected helper startup result: code=${code} stderr=${stderrBytes} stdout=${stdout.slice(0, 300)}`);
+          }
+          resolve();
+        } catch (error) {
+          reject(new Error(`Pi Agent helper startup smoke test failed: ${error instanceof Error ? error.message : String(error)}`));
+        }
+      });
+      child.stdin.end('{"id":"1","type":"get_state"}\n');
+    });
+  } finally {
+    await rm(piAgentRoot, { recursive: true, force: true });
+  }
+}
+
+const piAgentHelperBuild = build({
+  entryPoints: [path.join(root, "src/runtime/worker/pi-agent/piAgentHelperEntry.ts")],
+  outfile: path.join(runtimeDir, "pi-agent-helper.mjs"),
+  bundle: true,
+  platform: "node",
+  format: "esm",
+  target: "node22",
+  banner: { js: requireShim },
+  metafile: true,
+  logLevel: "info",
+});
+desktopBuilds.push(piAgentHelperBuild.then(async (result) => {
+  const output = Object.values(result.metafile.outputs).find((item) => item.entryPoint?.endsWith("piAgentHelperEntry.ts"));
+  if (!output) throw new Error("Pi Agent helper build metadata is missing its entry output");
+  const inputs = Object.entries(output.inputs).filter(([, detail]) => detail.bytesInOutput > 0).map(([input]) => input);
+  const missing = ["pi-agent-core", "pi-coding-agent"].filter((name) =>
+    !inputs.some((input) => input.includes(`${path.sep}@earendil-works${path.sep}${name}${path.sep}`)));
+  if (missing.length) throw new Error(`Pi Agent helper is missing required dependencies: ${missing.join(", ")}`);
+  // The bundled CLI reads its built-in theme JSONs from disk at startup.
+  // Ship them next to the helper and point PI_PACKAGE_DIR at the assets root.
+  const assetsDir = path.join(runtimeDir, "pi-agent-assets");
+  const themeSource = path.join(root, "node_modules", "@earendil-works", "pi-coding-agent", "dist", "modes", "interactive", "theme");
+  const themeTarget = path.join(assetsDir, "dist", "modes", "interactive", "theme");
+  await mkdir(themeTarget, { recursive: true });
+  for (const name of ["dark.json", "light.json"]) {
+    await copyFile(path.join(themeSource, name), path.join(themeTarget, name));
+  }
+  await verifyPiAgentHelperStartup(path.join(runtimeDir, "pi-agent-helper.mjs"), assetsDir);
+  const helperBytes = await readFile(path.join(runtimeDir, "pi-agent-helper.mjs"));
+  const licenseBytes = await readFile(path.join(root, "THIRD_PARTY_LICENSES.md"));
+  await writeFile(path.join(runtimeDir, "pi-agent-build-manifest.json"), JSON.stringify({
+    schemaVersion: 1,
+    piAgentCoreVersion: "0.84.2",
+    piCodingAgentVersion: "0.84.2",
+    license: "MIT",
+    node: ">=22.19.0",
+    helperSha256: createHash("sha256").update(helperBytes).digest("hex"),
+    themeAssetsSha256: {
+      dark: createHash("sha256").update(await readFile(path.join(themeTarget, "dark.json"))).digest("hex"),
+      light: createHash("sha256").update(await readFile(path.join(themeTarget, "light.json"))).digest("hex"),
+    },
+    thirdPartyLicensesSha256: createHash("sha256").update(licenseBytes).digest("hex"),
+    inputs: inputs.sort(),
   }, null, 2));
 }));
 

--- a/src/app-data/appDatabaseMigrations.ts
+++ b/src/app-data/appDatabaseMigrations.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import type Database from "better-sqlite3";
 
-export const APP_DATABASE_SCHEMA_VERSION = 12;
+export const APP_DATABASE_SCHEMA_VERSION = 14;
 
 export type AppDatabaseCompatibilityReason = "integrity" | "future" | "schema";
 
@@ -820,6 +820,39 @@ const APP_V12_GENERATION_PROVIDERS_AUDIO_SQL = `
 
 const APP_SCHEMA_V12 = new Map(APP_SCHEMA_V11);
 
+const APP_V13_PI_BUILTIN_RUNTIME_AND_AGENT_ONBOARDING_SQL = `
+  ALTER TABLE installation_state ADD COLUMN agent_onboarding_completed_at INTEGER;
+
+  INSERT INTO runtime_profiles (
+    runtime_id, enabled, default_binding_mode,
+    default_model_configuration_id, default_model_configuration_revision,
+    current_revision, updated_at
+  ) VALUES
+    ('pi-builtin', 1, 'unset', NULL, NULL, 1, unixepoch() * 1000);
+  INSERT INTO runtime_profile_revisions (
+    runtime_id, revision, executable_preference, runtime_options_json, created_at
+  ) VALUES
+    ('pi-builtin', 1, NULL, '{}', unixepoch() * 1000);
+`;
+
+const APP_SCHEMA_V13 = new Map(APP_SCHEMA_V12);
+APP_SCHEMA_V13.set("installation_state", [
+  ...(APP_SCHEMA_V12.get("installation_state") ?? []),
+  "agent_onboarding_completed_at",
+]);
+
+// Applied after v13 shipped: model configurations created before the built-in
+// runtime existed carry compatibility snapshots without a pi-builtin key, so
+// they could not be bound or pinned to pi-builtin. The backfill is idempotent.
+const APP_V14_PI_BUILTIN_MODEL_COMPAT_BACKFILL_SQL = `
+  UPDATE model_configuration_revisions
+  SET runtime_compatibility_snapshot_json = json_set(
+    runtime_compatibility_snapshot_json, '$."pi-builtin"', json_object('supported', json('true'))
+  );
+`;
+
+const APP_SCHEMA_V14 = new Map(APP_SCHEMA_V13);
+
 function baselineChecksum(): string {
   return createHash("sha256").update(APP_BASELINE_SQL).digest("hex");
 }
@@ -881,7 +914,7 @@ function assertIntegrity(sqlite: Database.Database, dbPath: string): void {
 
 function assertSchema(sqlite: Database.Database, dbPath: string, version = APP_DATABASE_SCHEMA_VERSION): void {
   const missing: string[] = [];
-  const expectedSchema = version >= 12 ? APP_SCHEMA_V12 : version >= 11 ? APP_SCHEMA_V11 : version >= 10 ? APP_SCHEMA_V10 : version >= 9 ? APP_SCHEMA_V9 : version >= 8 ? APP_SCHEMA_V8 : version >= 7 ? APP_SCHEMA_V7 : version >= 6 ? APP_SCHEMA_V6 : version >= 5 ? APP_SCHEMA_V5 : version >= 4 ? APP_SCHEMA_V4 : version >= 3 ? APP_SCHEMA_V3 : version >= 2 ? APP_SCHEMA_V2 : APP_SCHEMA_V1;
+  const expectedSchema = version >= 14 ? APP_SCHEMA_V14 : version >= 13 ? APP_SCHEMA_V13 : version >= 12 ? APP_SCHEMA_V12 : version >= 11 ? APP_SCHEMA_V11 : version >= 10 ? APP_SCHEMA_V10 : version >= 9 ? APP_SCHEMA_V9 : version >= 8 ? APP_SCHEMA_V8 : version >= 7 ? APP_SCHEMA_V7 : version >= 6 ? APP_SCHEMA_V6 : version >= 5 ? APP_SCHEMA_V5 : version >= 4 ? APP_SCHEMA_V4 : version >= 3 ? APP_SCHEMA_V3 : version >= 2 ? APP_SCHEMA_V2 : APP_SCHEMA_V1;
   for (const [table, requiredColumns] of expectedSchema) {
     const actual = tableColumns(sqlite, table);
     if (actual.size === 0) {
@@ -1009,7 +1042,7 @@ function assertSchema(sqlite: Database.Database, dbPath: string, version = APP_D
       "SELECT runtime_configuration_epoch FROM installation_state WHERE singleton_key = 1",
     ).pluck().get());
     if (!Number.isSafeInteger(epoch) || epoch < 1) missing.push("installation_state.runtime_configuration_epoch (value)");
-    for (const runtimeId of ["claude", "codex", "opencode", "pi"]) {
+    for (const runtimeId of ["claude", "codex", "opencode", "pi", ...(version >= 13 ? ["pi-builtin"] : [])]) {
       const row = sqlite.prepare(`
         SELECT default_binding_mode, default_model_configuration_id, default_model_configuration_revision
         FROM runtime_profiles WHERE runtime_id = ?
@@ -1128,6 +1161,8 @@ function expectedJournal(version: number) {
     ...(version >= 10 ? [{ version: 10, name: "appearance-color-mode", checksum: migrationChecksum(APP_V10_APPEARANCE_COLOR_MODE_SQL) }] : []),
     ...(version >= 11 ? [{ version: 11, name: "generation-providers", checksum: migrationChecksum(APP_V11_GENERATION_PROVIDERS_SQL) }] : []),
     ...(version >= 12 ? [{ version: 12, name: "generation-providers-audio", checksum: migrationChecksum(APP_V12_GENERATION_PROVIDERS_AUDIO_SQL) }] : []),
+    ...(version >= 13 ? [{ version: 13, name: "pi-builtin-runtime-and-agent-onboarding", checksum: migrationChecksum(APP_V13_PI_BUILTIN_RUNTIME_AND_AGENT_ONBOARDING_SQL) }] : []),
+    ...(version >= 14 ? [{ version: 14, name: "pi-builtin-model-compat-backfill", checksum: migrationChecksum(APP_V14_PI_BUILTIN_MODEL_COMPAT_BACKFILL_SQL) }] : []),
   ];
 }
 
@@ -1432,6 +1467,30 @@ export function migrateAppDatabase(sqlite: Database.Database, dbPath: string, op
       `).run(12, "generation-providers-audio", migrationChecksum(APP_V12_GENERATION_PROVIDERS_AUDIO_SQL), Date.now());
     });
     applyGenerationProvidersAudio.immediate();
+  }
+  if (version < 13) {
+    const applyPiBuiltinRuntime = sqlite.transaction(() => {
+      sqlite.exec(APP_V13_PI_BUILTIN_RUNTIME_AND_AGENT_ONBOARDING_SQL);
+      assertSchema(sqlite, dbPath, 13);
+      sqlite.pragma("user_version = 13");
+      sqlite.prepare(`
+        INSERT INTO app_migration_journal (version, name, checksum, applied_at)
+        VALUES (?, ?, ?, ?)
+      `).run(13, "pi-builtin-runtime-and-agent-onboarding", migrationChecksum(APP_V13_PI_BUILTIN_RUNTIME_AND_AGENT_ONBOARDING_SQL), Date.now());
+    });
+    applyPiBuiltinRuntime.immediate();
+  }
+  if (version < 14) {
+    const applyPiBuiltinCompatBackfill = sqlite.transaction(() => {
+      sqlite.exec(APP_V14_PI_BUILTIN_MODEL_COMPAT_BACKFILL_SQL);
+      assertSchema(sqlite, dbPath, 14);
+      sqlite.pragma("user_version = 14");
+      sqlite.prepare(`
+        INSERT INTO app_migration_journal (version, name, checksum, applied_at)
+        VALUES (?, ?, ?, ?)
+      `).run(14, "pi-builtin-model-compat-backfill", migrationChecksum(APP_V14_PI_BUILTIN_MODEL_COMPAT_BACKFILL_SQL), Date.now());
+    });
+    applyPiBuiltinCompatBackfill.immediate();
   }
   assertCompatibleAppDatabase(sqlite, dbPath, { requireCurrentVersion: true });
 }

--- a/src/daemon/runtimes.ts
+++ b/src/daemon/runtimes.ts
@@ -9,14 +9,20 @@ import { cursorRuntime } from "./cursorRuntime.js";
 import { hermesRuntime } from "./hermesRuntime.js";
 import { runtimeCommandAvailable } from "./runtimeProcess.js";
 import { RUNTIME_CATALOG } from "../local-runtime/runtimeCatalog.js";
+import { existsSync } from "node:fs";
+import { resolvePiAgentHelper } from "../runtime/worker/pi-agent/piAgentHelperResolver.js";
 import type { Runtime } from "./runtime.js";
 
 export type { Runtime, RuntimeSession, RuntimeCallbacks, StartOpts, TrajectoryEntry } from "./runtime.js";
 
 export function detectRuntimes(env: NodeJS.ProcessEnv = process.env): string[] {
-  return RUNTIME_CATALOG
-    .filter((runtime) => runtimeCommandAvailable(runtime.command, env))
+  const detected = RUNTIME_CATALOG
+    .filter((runtime) => runtime.command && runtimeCommandAvailable(runtime.command, env))
     .map((runtime) => runtime.id);
+  // The built-in Pi Agent ships with the app: report it whenever the bundled
+  // helper is resolvable, so no locally installed Agent CLI is required.
+  if (!existsSync(resolvePiAgentHelper())) return detected;
+  return [...detected, "pi-builtin"];
 }
 
 const REG: Record<string, Runtime> = { claude: claudeRuntime, codex: codexRuntime, copilot: copilotRuntime, opencode: opencodeRuntime, kimi: kimiRuntime, pi: piRuntime, cursor: cursorRuntime, hermes: hermesRuntime };

--- a/src/desktop/processCommands.ts
+++ b/src/desktop/processCommands.ts
@@ -25,6 +25,7 @@ export type DesktopProcessCommandOptions = PackagedProcessCommandOptions | Devel
 export function buildDesktopProcessCommands(options: DesktopProcessCommandOptions): DesktopProcessCommands {
   if (options.mode === "development") {
     const advisorHelper = path.join(options.appRoot, "desktop", "dist", "runtime", "pi-advisor-helper.mjs");
+    const agentHelper = path.join(options.appRoot, "desktop", "dist", "runtime", "pi-agent-helper.mjs");
     return {
       core: {
         command: options.executable,
@@ -40,7 +41,7 @@ export function buildDesktopProcessCommands(options: DesktopProcessCommandOption
         command: options.executable,
         args: [options.tsxCli, "src/daemon/index.ts"],
         cwd: options.appRoot,
-        env: { KITH_SPACE_PI_ADVISOR_HELPER: advisorHelper },
+        env: { KITH_SPACE_PI_ADVISOR_HELPER: advisorHelper, KITH_SPACE_PI_AGENT_HELPER: agentHelper },
       },
       vite: {
         command: options.executable,
@@ -53,6 +54,7 @@ export function buildDesktopProcessCommands(options: DesktopProcessCommandOption
 
   const electronNodeEnv: NodeJS.ProcessEnv = { ELECTRON_RUN_AS_NODE: "1" };
   const advisorHelper = path.join(options.resourcesPath, "runtime", "pi-advisor-helper.mjs");
+  const agentHelper = path.join(options.resourcesPath, "runtime", "pi-agent-helper.mjs");
   return {
     core: {
       command: options.executable,
@@ -71,7 +73,7 @@ export function buildDesktopProcessCommands(options: DesktopProcessCommandOption
       command: options.executable,
       args: [path.join(options.resourcesPath, "runtime", "worker.mjs")],
       cwd: options.resourcesPath,
-      env: { ...electronNodeEnv, KITH_SPACE_PI_ADVISOR_HELPER: advisorHelper },
+      env: { ...electronNodeEnv, KITH_SPACE_PI_ADVISOR_HELPER: advisorHelper, KITH_SPACE_PI_AGENT_HELPER: agentHelper },
     },
   };
 }

--- a/src/local-runtime/runtimeCatalog.test.ts
+++ b/src/local-runtime/runtimeCatalog.test.ts
@@ -15,8 +15,21 @@ test("runtime availability keeps the full catalog and sorts installed runtimes f
   );
 });
 
+test("the built-in Pi Agent is always available without any installed CLI", () => {
+  const result = runtimeAvailability([]);
+  const builtin = result.find((runtime) => runtime.id === "pi-builtin");
+  assert.equal(builtin?.installed, true);
+  assert.equal(builtin?.builtIn, true);
+  assert.equal(builtin?.label, "Pi Agent（内置）");
+});
+
 test("unknown worker capabilities do not leak into the supported runtime catalog", () => {
-  assert.equal(runtimeAvailability(["unknown-runtime"]).some((runtime) => runtime.installed), false);
+  const result = runtimeAvailability(["unknown-runtime" as any]);
+  assert.equal(result.some((runtime) => runtime.id === ("unknown-runtime" as any)), false);
+  assert.deepEqual(
+    result.filter((runtime) => runtime.installed).map((runtime) => runtime.id),
+    ["pi-builtin"],
+  );
 });
 
 test("OpenCode creation requires an explicit provider/model", () => {

--- a/src/local-runtime/runtimeCatalog.ts
+++ b/src/local-runtime/runtimeCatalog.ts
@@ -5,6 +5,7 @@ export const RUNTIME_CATALOG = [
   { id: "opencode", label: "OpenCode", command: "opencode" },
   { id: "kimi", label: "Kimi Code", command: "kimi" },
   { id: "pi", label: "Pi", command: "pi" },
+  { id: "pi-builtin", label: "Pi Agent（内置）", command: null, alwaysAvailable: true },
   { id: "cursor", label: "Cursor", command: "cursor-agent" },
   { id: "hermes", label: "Hermes", command: "hermes" },
 ] as const;
@@ -15,12 +16,21 @@ export interface RuntimeAvailability {
   id: RuntimeId;
   label: string;
   installed: boolean;
+  builtIn?: boolean;
 }
 
 export function runtimeAvailability(installedRuntimeIds: Iterable<string>): RuntimeAvailability[] {
   const installed = new Set(installedRuntimeIds);
   return RUNTIME_CATALOG
-    .map(({ id, label }) => ({ id, label, installed: installed.has(id) }))
+    .map((entry) => {
+      const builtIn = "alwaysAvailable" in entry && entry.alwaysAvailable === true;
+      return {
+        id: entry.id,
+        label: entry.label,
+        installed: builtIn || installed.has(entry.id),
+        ...(builtIn ? { builtIn: true } : {}),
+      };
+    })
     .sort((a, b) => Number(b.installed) - Number(a.installed));
 }
 

--- a/src/model-control/modelConfigurationService.ts
+++ b/src/model-control/modelConfigurationService.ts
@@ -22,17 +22,17 @@ export interface SaveModelConfigurationInput {
 }
 
 const SUPPORTED: Record<string, readonly RuntimeId[]> = {
-  "anthropic-messages": ["claude", "opencode", "pi"],
-  "openai-responses": ["codex", "opencode", "pi"],
-  "openai-completions": ["opencode", "pi"],
-  "google-generative-ai": ["opencode", "pi"],
-  "google-vertex": ["claude", "opencode", "pi"],
-  "bedrock-converse-stream": ["claude", "pi"],
+  "anthropic-messages": ["claude", "opencode", "pi", "pi-builtin"],
+  "openai-responses": ["codex", "opencode", "pi", "pi-builtin"],
+  "openai-completions": ["opencode", "pi", "pi-builtin"],
+  "google-generative-ai": ["opencode", "pi", "pi-builtin"],
+  "google-vertex": ["claude", "opencode", "pi", "pi-builtin"],
+  "bedrock-converse-stream": ["claude", "pi", "pi-builtin"],
 };
 
 export function computeRuntimeCompatibility(apiKind: string): Partial<Record<RuntimeId | "pi_sdk", RuntimeCompatibility>> {
-  const supported = new Set(SUPPORTED[apiKind] ?? ["pi"]);
-  return Object.fromEntries((["claude", "codex", "opencode", "pi"] as RuntimeId[]).map((runtimeId) => [
+  const supported = new Set(SUPPORTED[apiKind] ?? ["pi", "pi-builtin"]);
+  return Object.fromEntries((["claude", "codex", "opencode", "pi", "pi-builtin"] as RuntimeId[]).map((runtimeId) => [
     runtimeId,
     supported.has(runtimeId)
       ? { supported: true }

--- a/src/model-control/piConfigModelImportService.test.ts
+++ b/src/model-control/piConfigModelImportService.test.ts
@@ -1,0 +1,192 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const home = mkdtempSync(path.join(os.tmpdir(), "kith-pi-model-import-"));
+process.env.KITH_SPACE_HOME = home;
+
+const { closeAppDatabase } = await import("../app-data/appDatabase.js");
+const { ModelProviderConnectionService } = await import("./modelProviderConnectionService.js");
+const { ModelConfigurationService } = await import("./modelConfigurationService.js");
+const { PiConfigModelImportService } = await import("./piConfigModelImportService.js");
+const { providerCredentialPort } = await import("../advisor-provider/credentialPort.js");
+
+const piRoot = mkdtempSync(path.join(os.tmpdir(), "kith-pi-cli-config-"));
+const modelsPath = path.join(piRoot, "models.json");
+const authPath = path.join(piRoot, "auth.json");
+
+function writeConfig(models: unknown, auth: unknown = {}): void {
+  writeFileSync(modelsPath, JSON.stringify(models), { encoding: "utf8" });
+  writeFileSync(authPath, JSON.stringify(auth), { encoding: "utf8" });
+}
+
+const baseModels = {
+  providers: {
+    anthropic: {
+      baseUrl: "https://api.anthropic.com",
+      api: "anthropic-messages",
+      models: [{ id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" }],
+    },
+    deepseek: {
+      baseUrl: "https://api.deepseek.com",
+      apiKey: "$DEEPSEEK_API_KEY",
+      api: "openai-completions",
+      models: [{ id: "deepseek-v4-flash", name: "DeepSeek V4 Flash" }],
+    },
+    openai: {
+      baseUrl: "https://api.openai.com/v1",
+      apiKey: "sk-literal-key",
+      api: "openai-responses",
+      models: [{ id: "gpt-5.2", name: "GPT-5.2" }],
+    },
+    local: {
+      baseUrl: "http://127.0.0.1:11434",
+      api: "openai-completions",
+      models: [{ id: "qwen3:8b", name: "Qwen3 8B" }],
+    },
+    mistral: {
+      baseUrl: "https://api.mistral.ai",
+      api: "mistral-conversations",
+      models: [{ id: "mistral-large-latest", name: "Mistral Large" }],
+    },
+    dangerous: {
+      baseUrl: "https://api.example.com",
+      apiKey: "!security find-generic-password",
+      api: "openai-completions",
+      models: [{ id: "example-model", name: "Example" }],
+    },
+    compound: {
+      baseUrl: "https://api.example.com",
+      apiKey: "${KEY_PREFIX}_${KEY_SUFFIX}",
+      api: "openai-completions",
+      models: [{ id: "compound-model", name: "Compound" }],
+    },
+  },
+};
+
+test.after(() => {
+  closeAppDatabase();
+  rmSync(home, { recursive: true, force: true });
+  rmSync(piRoot, { recursive: true, force: true });
+});
+
+test("Pi config import preview sanitizes providers, credentials, and unsupported APIs", () => {
+  writeConfig(baseModels, {
+    openai: { type: "api_key", key: "sk-auth-key" },
+  });
+  const service = new PiConfigModelImportService();
+  const preview = service.preview(piRoot);
+
+  const byId = new Map(preview.providers.map((provider) => [provider.backendId, provider]));
+  assert.deepEqual([...byId.keys()].sort(), ["anthropic", "compound", "dangerous", "deepseek", "local", "openai"]);
+
+  const anthropic = byId.get("anthropic")!;
+  assert.equal(anthropic.apiKind, "anthropic-messages");
+  assert.equal(anthropic.canonicalOrigin, "https://api.anthropic.com");
+  assert.equal(anthropic.credential.kind, "keyless_local");
+  assert.equal(anthropic.models[0]?.id, "claude-sonnet-4-6");
+
+  const deepseek = byId.get("deepseek")!;
+  assert.deepEqual(deepseek.credential, { kind: "env_ref", env: "DEEPSEEK_API_KEY", importable: Boolean(process.env.DEEPSEEK_API_KEY) });
+
+  // auth.json api_key wins over the literal models.json key
+  assert.equal(byId.get("openai")!.credential.kind, "pi_cli_auth");
+
+  const local = byId.get("local")!;
+  assert.equal(local.networkClass, "loopback");
+  assert.equal(local.credential.kind, "keyless_local");
+
+  // !command and compound interpolation are rejected; mistral's api is not importable
+  assert.equal(byId.get("dangerous")!.credential.kind, "keyless_local");
+  assert.equal(byId.get("compound")!.credential.kind, "keyless_local");
+  assert.equal(byId.has("mistral"), false);
+  assert.ok(preview.warnings.length >= 2);
+  assert.equal(preview.hasCredentialSecrets, true);
+});
+
+test("Pi config import apply creates provider connections and model configurations in one transaction", () => {
+  writeConfig(baseModels, {
+    openai: { type: "api_key", key: "sk-auth-key" },
+  });
+  const providers = new ModelProviderConnectionService();
+  const configurations = new ModelConfigurationService(providers);
+  const service = new PiConfigModelImportService(providers, configurations);
+  const preview = service.preview(piRoot);
+
+  const resultPromise = service.apply(piRoot, preview.sourceMtimeDigest);
+  return resultPromise.then((result) => {
+    assert.equal(result.applied, 6);
+    assert.deepEqual(result.skipped, []);
+
+    const connections = providers.list().filter((item) => item.connection.status === "active");
+    const byBackend = new Map(connections.map((item) => [item.revision.backendId, item]));
+    assert.equal(connections.length, 6);
+    assert.equal(byBackend.get("openai")!.revision.credentialSourceKind, "pi_cli_auth");
+    assert.equal(byBackend.get("deepseek")!.revision.credentialSourceKind,
+      process.env.DEEPSEEK_API_KEY ? "kith_secret" : "keyless_local");
+    assert.equal(byBackend.get("anthropic")!.revision.credentialSourceKind, "keyless_local");
+    assert.equal(byBackend.get("compound")!.revision.credentialSourceKind, "keyless_local");
+    assert.equal(byBackend.get("openai")!.revision.sourceKind, "pi_import");
+
+    const models = configurations.list().filter((item) => item.configuration.status === "active");
+    assert.equal(models.length, 6);
+    const openaiModel = models.find((item) => item.revision.modelId === "gpt-5.2");
+    assert.equal(openaiModel?.revision.providerConnectionId, byBackend.get("openai")!.connection.id);
+    assert.equal(openaiModel?.revision.runtimeCompatibilitySnapshot["pi-builtin"]?.supported, true);
+  });
+});
+
+test("Pi config import refuses drift between preview and apply, and skips existing providers", () => {
+  writeConfig(baseModels, {});
+  const providers = new ModelProviderConnectionService();
+  const configurations = new ModelConfigurationService(providers);
+  const service = new PiConfigModelImportService(providers, configurations);
+  const preview = service.preview(piRoot);
+
+  // Mutate the source after preview: apply must fail closed.
+  const mutated = JSON.parse(JSON.stringify(baseModels)) as any;
+  mutated.providers.openai.models[0].id = "gpt-5.3";
+  writeConfig(mutated, {});
+  return assert.rejects(() => service.apply(piRoot, preview.sourceMtimeDigest), /changed after preview/)
+    .then(() => {
+      // Restore and apply; the providers created by the previous test are
+      // skipped, and a second apply is a no-op with the same skips.
+      writeConfig(baseModels, {});
+      const fresh = service.preview(piRoot);
+      return service.apply(piRoot, fresh.sourceMtimeDigest).then((first) => {
+        assert.equal(first.applied, 0);
+        assert.deepEqual(first.skipped.sort(), ["anthropic", "compound", "dangerous", "deepseek", "local", "openai"]);
+        return service.apply(piRoot, fresh.sourceMtimeDigest).then((second) => {
+          assert.equal(second.applied, 0);
+          assert.deepEqual(second.skipped.sort(), ["anthropic", "compound", "dangerous", "deepseek", "local", "openai"]);
+        });
+      });
+    });
+});
+
+test("Pi config import stores a kith secret for a literal API key when auth.json has no entry", () => {
+  const literalModels = {
+    providers: {
+      "literal-provider": {
+        baseUrl: "https://api.literal.example.com",
+        apiKey: "sk-literal-only",
+        api: "openai-completions",
+        models: [{ id: "literal-model", name: "Literal Model" }],
+      },
+    },
+  };
+  writeConfig(literalModels, {});
+  const providers = new ModelProviderConnectionService();
+  const configurations = new ModelConfigurationService(providers);
+  const service = new PiConfigModelImportService(providers, configurations);
+  const preview = service.preview(piRoot);
+  return service.apply(piRoot, preview.sourceMtimeDigest).then(() => {
+    const literal = providers.list().find((item) => item.revision.backendId === "literal-provider")!;
+    assert.equal(literal.revision.credentialSourceKind, "kith_secret");
+    const identity = providerCredentialPort.identityForStoredRef(
+      literal.revision.credentialRef!, "literal-provider", "kith_secret");
+    assert.equal(identity, literal.revision.credentialIdentityDigest);
+  });
+});

--- a/src/model-control/piConfigModelImportService.ts
+++ b/src/model-control/piConfigModelImportService.ts
@@ -1,0 +1,347 @@
+import { createHash, randomUUID } from "node:crypto";
+import os from "node:os";
+import path from "node:path";
+import { appDataConnection, getContentHmacKey } from "../app-data/appDatabase.js";
+import { providerCredentialPort } from "../advisor-provider/credentialPort.js";
+import { PiCliConfigImporter } from "../advisor-provider/piCliConfigImporter.js";
+import { canonicalAdvisorOrigin } from "../advisor-provider/advisorModelCompiler.js";
+import type { AdvisorApiKind, AdvisorCredentialSourceKind } from "../advisor-provider/contracts.js";
+import { VerifiedConfigFileReader } from "../advisor-provider/verifiedConfigFileReader.js";
+import { ModelControlError } from "./contracts.js";
+import { ModelProviderBundleService, type SaveProviderBundleInput } from "./modelProviderBundleService.js";
+import { ModelProviderConnectionService } from "./modelProviderConnectionService.js";
+import { ModelConfigurationService } from "./modelConfigurationService.js";
+import { withRuntimeConfigurationChange } from "./runtimeConfigurationChange.js";
+import { markAgentsForRuntimeConfigurationChange } from "./runtimeConfigurationImpact.js";
+
+const IMPORTABLE_API_KINDS: ReadonlySet<AdvisorApiKind> = new Set<AdvisorApiKind>(
+  ["anthropic-messages", "openai-responses", "openai-completions", "google-generative-ai"],
+);
+
+const ENV_REF = /^\$(?:\{([A-Z_][A-Z0-9_]*)\}|([A-Z_][A-Z0-9_]*))$/;
+const DANGEROUS_ENV = /^(?:NODE_OPTIONS|PATH|HOME|USERPROFILE|XDG_.*|SHELL|BASH_ENV|ENV|NPM_.*|PNPM_.*|ELECTRON_.*|KITH_.*|HTTP_PROXY|HTTPS_PROXY|ALL_PROXY|NO_PROXY)$/;
+
+export type PiModelImportCredential =
+  | { kind: "pi_cli_auth" }
+  | { kind: "literal"; importable: boolean }
+  | { kind: "env_ref"; env: string; importable: boolean }
+  | { kind: "keyless_local" };
+
+export interface PiModelImportProviderDraft {
+  backendId: string;
+  displayName: string;
+  apiKind: AdvisorApiKind;
+  canonicalOrigin: string;
+  networkClass: "loopback" | "lan" | "public_cloud" | "custom";
+  models: Array<{ id: string; name: string }>;
+  credential: PiModelImportCredential;
+  warnings: string[];
+}
+
+export interface PiModelImportPreview {
+  root: string;
+  providers: PiModelImportProviderDraft[];
+  warnings: string[];
+  sourceMtimeDigest: string;
+  sourcePaths: string[];
+  hasCredentialSecrets: boolean;
+}
+
+export interface PiModelImportApplyResult {
+  preview: PiModelImportPreview;
+  applied: number;
+  skipped: string[];
+  unchanged: boolean;
+}
+
+function parseJson(buffer: Buffer | null): Record<string, unknown> {
+  if (!buffer) return {};
+  let value: unknown;
+  try { value = JSON.parse(buffer.toString("utf8")); } catch { throw new ModelControlError("import_conflict", "Pi config contains invalid JSON"); }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new ModelControlError("import_conflict", "Pi config root must be an object");
+  }
+  return value as Record<string, unknown>;
+}
+
+function apiKeyCredential(value: unknown, warnings: string[], pointer: string): PiModelImportCredential {
+  if (value === undefined || value === null || value === "") return { kind: "keyless_local" };
+  if (typeof value !== "string") {
+    warnings.push(`${pointer}: 凭据格式不受支持，已跳过`);
+    return { kind: "keyless_local" };
+  }
+  if (value.startsWith("!")) {
+    warnings.push(`${pointer}: 不导入命令式凭据（!command），请手动填写 API Key`);
+    return { kind: "keyless_local" };
+  }
+  const match = ENV_REF.exec(value);
+  if (match) {
+    const name = match[1] ?? match[2]!;
+    if (DANGEROUS_ENV.test(name)) {
+      warnings.push(`${pointer}: 拒绝从危险环境变量 ${name} 读取凭据，请手动填写 API Key`);
+      return { kind: "keyless_local" };
+    }
+    return { kind: "env_ref", env: name, importable: Boolean(process.env[name]) };
+  }
+  if (value.includes("$") || value.includes("${")) {
+    warnings.push(`${pointer}: 不支持复合环境变量插值，请手动填写 API Key`);
+    return { kind: "keyless_local" };
+  }
+  return { kind: "literal", importable: true };
+}
+
+function authCredentialAvailable(auth: Record<string, unknown>, backendId: string, now: number): boolean {
+  const entry = auth[backendId];
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) return false;
+  const candidate = entry as Record<string, unknown>;
+  if (candidate.type === "api_key") {
+    const key = candidate.key;
+    return typeof key === "string" && key.length > 0 && !key.startsWith("!") && !key.includes("$");
+  }
+  if (candidate.type === "oauth") {
+    return typeof candidate.access === "string" && candidate.access.length > 0
+      && Number.isFinite(candidate.expires) && Number(candidate.expires) > now;
+  }
+  return false;
+}
+
+/** Root used by both preview and the pi_cli_auth redemption path (~/.pi/agent). */
+export function piAgentConfigRoot(): string {
+  return path.join(os.homedir(), ".pi", "agent");
+}
+
+/**
+ * Read-only, sanitized import of the user's local Pi CLI configuration into
+ * Kith model provider connections + model configurations. Same security
+ * boundary as PiCliConfigImporter: no !command resolution, no compound env
+ * interpolation, dangerous env names rejected, symlinks/oversized files
+ * rejected, and nothing is ever written back to the Pi CLI configuration.
+ */
+export class PiConfigModelImportService {
+  constructor(
+    private readonly providers = new ModelProviderConnectionService(),
+    private readonly configurations = new ModelConfigurationService(providers),
+    private readonly bundles = new ModelProviderBundleService(providers, configurations),
+    private readonly reader = new VerifiedConfigFileReader(),
+    private readonly now: () => number = Date.now,
+  ) {}
+
+  preview(root: string = piAgentConfigRoot()): PiModelImportPreview {
+    const importer = new PiCliConfigImporter(this.reader, getContentHmacKey(), this.now);
+    const scan = importer.import(root);
+    const modelsFile = this.reader.read(root, "models.json", true);
+    const authFile = this.reader.read(root, "auth.json", true);
+    const models = parseJson(modelsFile?.buffer ?? null);
+    const auth = parseJson(authFile?.buffer ?? null);
+    const warnings = [...scan.warnings.map((item) => `${item.pointer}: ${item.code}`)];
+    const providerRoot = models.providers && typeof models.providers === "object" && !Array.isArray(models.providers)
+      ? models.providers as Record<string, unknown>
+      : models;
+    const providers: PiModelImportProviderDraft[] = [];
+    for (const [backendId, rawProvider] of Object.entries(providerRoot).slice(0, 64)) {
+      const draftWarnings: string[] = [];
+      if (!rawProvider || typeof rawProvider !== "object" || Array.isArray(rawProvider)) continue;
+      const provider = rawProvider as Record<string, unknown>;
+      const apiKind = typeof provider.api === "string" ? provider.api : "";
+      if (!IMPORTABLE_API_KINDS.has(apiKind as AdvisorApiKind)) {
+        draftWarnings.push(`接口类型 ${apiKind || "(未设置)"} 暂不支持，已跳过`);
+        continue;
+      }
+      const importableApiKind = apiKind as AdvisorApiKind;
+      const endpoint = typeof provider.baseUrl === "string" ? provider.baseUrl : "";
+      let canonicalOrigin = "";
+      let networkClass: PiModelImportProviderDraft["networkClass"] = "public_cloud";
+      try {
+        networkClass = /^https?:\/\/(?:127\.|localhost|\[::1\])/.test(endpoint) ? "loopback" : "public_cloud";
+        canonicalOrigin = canonicalAdvisorOrigin(endpoint, networkClass);
+      } catch {
+        draftWarnings.push(`API 地址无效，已跳过`);
+        continue;
+      }
+      const modelList = Array.isArray(provider.models)
+        ? provider.models.filter((item): item is Record<string, unknown> =>
+            Boolean(item) && typeof item === "object" && !Array.isArray(item)
+            && typeof (item as Record<string, unknown>).id === "string").slice(0, 512)
+        : [];
+      const modelsDraft = modelList.map((item) => ({
+        id: String(item.id),
+        name: typeof item.name === "string" && item.name ? item.name : String(item.id),
+      }));
+      if (modelsDraft.length === 0) {
+        draftWarnings.push("没有可导入的模型，已跳过");
+        continue;
+      }
+      const configured = apiKeyCredential(
+        provider.apiKey ?? provider.api_key ?? provider.token,
+        draftWarnings,
+        `models.json/providers/${backendId}/apiKey`,
+      );
+      const credential: PiModelImportCredential = authCredentialAvailable(auth, backendId, this.now())
+        ? { kind: "pi_cli_auth" }
+        : configured;
+      providers.push({
+        backendId,
+        displayName: backendId,
+        apiKind: importableApiKind,
+        canonicalOrigin,
+        networkClass,
+        models: modelsDraft,
+        credential,
+        warnings: draftWarnings,
+      });
+    }
+    const fileIdentities = [modelsFile, authFile].filter((file) => file != null)
+      .map((file) => file!.contentDigest);
+    const sourceMtimeDigest = createHash("sha256").update(fileIdentities.join("\0")).digest("hex");
+    return {
+      root,
+      providers,
+      warnings,
+      sourceMtimeDigest,
+      sourcePaths: [path.join(root, "models.json"), path.join(root, "auth.json")],
+      hasCredentialSecrets: providers.some((provider) =>
+        provider.credential.kind === "pi_cli_auth"
+        || provider.credential.kind === "literal"
+        || (provider.credential.kind === "env_ref" && provider.credential.importable)),
+    };
+  }
+
+  async apply(root: string, expectedSourceMtimeDigest: string): Promise<PiModelImportApplyResult> {
+    const preview = this.preview(root);
+    if (preview.sourceMtimeDigest !== expectedSourceMtimeDigest) {
+      throw new ModelControlError("import_conflict", "Pi configuration changed after preview");
+    }
+    const previous = appDataConnection().prepare(`
+      SELECT source_mtime_digest FROM cli_config_import_snapshots
+      WHERE runtime_id = 'pi' ORDER BY created_at DESC, id DESC LIMIT 1
+    `).get() as { source_mtime_digest: string } | undefined;
+    if (previous?.source_mtime_digest === preview.sourceMtimeDigest && preview.providers.length === 0) {
+      return { preview, applied: 0, skipped: [], unchanged: true };
+    }
+    const existing = new Set(this.providers.list()
+      .filter((item) => item.connection.status === "active")
+      .map((item) => item.revision.backendId));
+    const drafts = preview.providers.filter((provider) => !existing.has(provider.backendId));
+    const skipped = preview.providers
+      .filter((provider) => existing.has(provider.backendId))
+      .map((provider) => provider.backendId);
+    if (drafts.length === 0) {
+      return { preview, applied: 0, skipped, unchanged: previous?.source_mtime_digest === preview.sourceMtimeDigest };
+    }
+    const secretSourceIdentity = new PiCliConfigImporter(this.reader, getContentHmacKey(), this.now)
+      .import(root).secretSourceIdentity;
+    const applied = await withRuntimeConfigurationChange(() => {
+      const sqlite = appDataConnection();
+      const result = sqlite.transaction(() => {
+        let count = 0;
+        for (const draft of drafts) {
+          const input = this.credentialInput(draft, root, secretSourceIdentity);
+          const provider = this.providers.createWithinConfigurationChange(input);
+          for (const model of draft.models.slice(0, 256)) {
+            this.configurations.createWithinConfigurationChange({
+              displayName: model.name,
+              providerConnectionId: provider.connection.id,
+              modelId: model.id,
+            });
+          }
+          count += 1;
+        }
+        return count;
+      }).immediate();
+      markAgentsForRuntimeConfigurationChange({ runtimeIds: ["pi", "pi-builtin"] });
+      return result;
+    });
+    const snapshot = appDataConnection().prepare(`
+      INSERT INTO cli_config_import_snapshots (
+        id, runtime_id, source_paths_digest, source_mtime_digest, sanitized_payload_json, warnings_json, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)
+    `);
+    snapshot.run(
+      randomUUID(),
+      "pi",
+      createHash("sha256").update(preview.sourcePaths.join("\0")).digest("hex"),
+      preview.sourceMtimeDigest,
+      JSON.stringify(preview.providers.map((provider) => ({
+        backendId: provider.backendId,
+        apiKind: provider.apiKind,
+        canonicalOrigin: provider.canonicalOrigin,
+        modelIds: provider.models.map((model) => model.id),
+        credentialKind: provider.credential.kind,
+      }))),
+      JSON.stringify([...preview.warnings, ...preview.providers.flatMap((provider) => provider.warnings)]),
+      Date.now(),
+    );
+    return { preview, applied, skipped, unchanged: false };
+  }
+
+  private credentialInput(
+    draft: PiModelImportProviderDraft,
+    root: string,
+    secretSourceIdentity: string,
+  ): SaveProviderBundleInput["provider"] {
+    const base = {
+      displayName: draft.displayName,
+      backendId: draft.backendId,
+      apiKind: draft.apiKind,
+      canonicalOrigin: draft.canonicalOrigin,
+      networkClass: draft.networkClass,
+      dataPolicyRevision: "human-confirmed-v1",
+      dataPolicyProvenance: "human_asserted" as const,
+      allowedEgress: [draft.canonicalOrigin],
+      capabilitySnapshot: {},
+      sourceKind: "pi_import" as const,
+      sourceSnapshotDigest: `pi_import:${secretSourceIdentity}`,
+    };
+    if (draft.credential.kind === "pi_cli_auth") {
+      const stored = providerCredentialPort.storePiCliSource(draft.backendId, root, secretSourceIdentity);
+      return {
+        ...base,
+        credentialSourceKind: "pi_cli_auth" as AdvisorCredentialSourceKind,
+        credentialRef: stored.credentialRef,
+        credentialIdentityDigest: stored.credentialIdentityDigest,
+      };
+    }
+    if (draft.credential.kind === "literal" && draft.credential.importable) {
+      const literal = this.readLiteralApiKey(root, draft.backendId);
+      if (literal) {
+        const stored = providerCredentialPort.storeKithSecret(draft.backendId, literal);
+        return {
+          ...base,
+          credentialSourceKind: "kith_secret",
+          credentialRef: stored.credentialRef,
+          credentialIdentityDigest: stored.credentialIdentityDigest,
+        };
+      }
+    }
+    if (draft.credential.kind === "env_ref" && draft.credential.importable) {
+      const value = process.env[draft.credential.env];
+      if (value) {
+        const stored = providerCredentialPort.storeKithSecret(draft.backendId, value);
+        return {
+          ...base,
+          credentialSourceKind: "kith_secret",
+          credentialRef: stored.credentialRef,
+          credentialIdentityDigest: stored.credentialIdentityDigest,
+        };
+      }
+    }
+    return { ...base, credentialSourceKind: "keyless_local" };
+  }
+
+  private readLiteralApiKey(root: string, backendId: string): string | null {
+    const modelsFile = this.reader.read(root, "models.json", true);
+    if (!modelsFile) return null;
+    const models = parseJson(modelsFile.buffer);
+    const providerRoot = models.providers && typeof models.providers === "object" && !Array.isArray(models.providers)
+      ? models.providers as Record<string, unknown>
+      : models;
+    const provider = providerRoot[backendId];
+    if (!provider || typeof provider !== "object" || Array.isArray(provider)) return null;
+    const value = (provider as Record<string, unknown>).apiKey
+      ?? (provider as Record<string, unknown>).api_key
+      ?? (provider as Record<string, unknown>).token;
+    return typeof value === "string" && value.length > 0
+      && !value.startsWith("!") && !value.includes("$") && value.length <= 64 * 1024
+      ? value : null;
+  }
+}

--- a/src/personal-setup/agentOnboardingService.test.ts
+++ b/src/personal-setup/agentOnboardingService.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const home = mkdtempSync(path.join(os.tmpdir(), "kith-onboarding-"));
+process.env.KITH_SPACE_HOME = home;
+
+const { closeAppDatabase, registerHomeSpace } = await import("../app-data/appDatabase.js");
+const { AgentOnboardingService } = await import("./agentOnboardingService.js");
+
+test.after(() => {
+  closeAppDatabase();
+  rmSync(home, { recursive: true, force: true });
+});
+
+test("agent onboarding starts pending, completes once, and stays completed", () => {
+  const service = new AgentOnboardingService();
+  registerHomeSpace({ id: "home-1", name: "Home", slug: "home", rootPath: path.join(home, "home") });
+
+  const initial = service.status();
+  assert.equal(initial.pending, true);
+  assert.equal(initial.completedAt, null);
+  assert.equal(initial.homeSpaceId, "home-1");
+  assert.equal(initial.homeAgentCount, 0);
+
+  const completed = service.complete();
+  assert.equal(completed.pending, false);
+  assert.equal(completed.completedAt, completed.completedAt); // number
+
+  const again = service.complete();
+  assert.equal(again.pending, false);
+  assert.equal(again.completedAt, completed.completedAt);
+});

--- a/src/personal-setup/agentOnboardingService.ts
+++ b/src/personal-setup/agentOnboardingService.ts
@@ -1,0 +1,45 @@
+import { appDataConnection, getHomeSpaceId } from "../app-data/appDatabase.js";
+import { dbForSpace } from "../db/index.js";
+import * as schema from "../db/schema.js";
+
+export interface AgentOnboardingStatus {
+  pending: boolean;
+  completedAt: number | null;
+  homeSpaceId: string | null;
+  homeAgentCount: number;
+}
+
+/**
+ * One-time "create your first Agent" onboarding gate. The wizard shows while
+ * `agent_onboarding_completed_at` is NULL (per installation, app.db v13) and
+ * completes on explicit finish or skip; a manually created Agent does not
+ * silently dismiss it.
+ */
+export class AgentOnboardingService {
+  status(): AgentOnboardingStatus {
+    const sqlite = appDataConnection();
+    const completedAt = sqlite.prepare(`
+      SELECT agent_onboarding_completed_at FROM installation_state WHERE singleton_key = 1
+    `).pluck().get() as number | null;
+    const homeSpaceId = getHomeSpaceId() ?? null;
+    let homeAgentCount = 0;
+    if (homeSpaceId) {
+      try {
+        homeAgentCount = dbForSpace(homeSpaceId).select().from(schema.agents).all().length;
+      } catch {
+        homeAgentCount = 0;
+      }
+    }
+    return { pending: completedAt === null, completedAt, homeSpaceId, homeAgentCount };
+  }
+
+  complete(): AgentOnboardingStatus {
+    const sqlite = appDataConnection();
+    const now = Date.now();
+    sqlite.prepare(`
+      UPDATE installation_state SET agent_onboarding_completed_at = ?
+      WHERE singleton_key = 1 AND agent_onboarding_completed_at IS NULL
+    `).run(now);
+    return this.status();
+  }
+}

--- a/src/runtime/adapters/piBuiltinRpcRuntimeV2.test.ts
+++ b/src/runtime/adapters/piBuiltinRpcRuntimeV2.test.ts
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { mkdtempSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { PassThrough } from "node:stream";
+import test from "node:test";
+import type { ChildProcess } from "node:child_process";
+import { createPiBuiltinRpcRuntimeV2, piAgentAssetsDir } from "./piBuiltinRpcRuntimeV2.js";
+
+class FakeHelper extends EventEmitter {
+  stdin = new PassThrough();
+  stdout = new PassThrough();
+  stderr = new PassThrough();
+  writes: any[] = [];
+
+  constructor() {
+    super();
+    let buffer = "";
+    this.stdin.on("data", (chunk) => {
+      buffer += chunk.toString("utf8");
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+      for (const line of lines) {
+        if (!line) continue;
+        const command = JSON.parse(line);
+        this.writes.push(command);
+        if (command.type === "get_state") this.line({
+          id: command.id, type: "response", command: "get_state", success: true,
+          data: { sessionId: "builtin-session-1", sessionFile: "/must/not/persist" },
+        });
+        else if (command.type === "prompt") this.line({
+          id: command.id, type: "response", command: "prompt", success: true,
+        });
+        else if (command.type === "abort") this.line({
+          id: command.id, type: "response", command: "abort", success: true,
+        });
+      }
+    });
+  }
+
+  line(value: unknown) { this.stdout.write(`${JSON.stringify(value)}\n`); }
+  kill() { return true; }
+}
+
+function options(root: string) {
+  return {
+    runtimeSessionId: "runtime-session-1", sessionGeneration: 2, workerGeneration: 3,
+    address: { spaceId: "space", agentId: "agent", surfaceKind: "channel" as const, surfaceId: "channel" },
+    cwd: root, runtimeStateDir: root, model: "deepseek/deepseek-v4-flash",
+    runtimeConfig: {
+      compiledRuntimeConfiguration: {
+        args: ["--mode", "rpc", "--provider", "kith", "--model", "deepseek-v4-flash",
+          "--no-approve", "--no-context-files", "--no-extensions", "--no-skills",
+          "--no-prompt-templates", "--no-themes"],
+        ephemeralFiles: [], fingerprint: "config",
+      },
+    },
+    engineSessionId: null, restoredSnapshot: null,
+    systemPrompt: { text: "System", version: "1", digest: "prompt" },
+    mcpBootstrap: { mode: "none" as const, serverName: "kith", descriptor: { capabilityMode: "cli_gateway" } },
+    env: { PI_CODING_AGENT_DIR: "/private/pi-builtin-home", KITH_PI_API_KEY: "activation-key" },
+    broker: { sessionHandle: "handle", endpoint: "http://127.0.0.1" },
+  };
+}
+
+async function waitForCommand(fake: FakeHelper, type: string): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    if (fake.writes.some((command) => command.type === type)) return;
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+  throw new Error(`missing Pi helper RPC command ${type}`);
+}
+
+test("the built-in Pi runtime spawns the bundled helper with assets and managed config passthrough", async () => {
+  const fake = new FakeHelper();
+  const root = mkdtempSync(path.join(os.tmpdir(), "kith-pi-builtin-"));
+  let spawnedCommand = "";
+  let spawnedArgs: string[] = [];
+  let spawnedEnv: NodeJS.ProcessEnv = {};
+  const runtime = createPiBuiltinRpcRuntimeV2("/bundled/pi-agent-helper.mjs", (command, args, spawnOptions) => {
+    spawnedCommand = command;
+    spawnedArgs = args;
+    spawnedEnv = spawnOptions.env;
+    return fake as unknown as ChildProcess;
+  });
+  const session = await runtime.openSession(options(root));
+  await waitForCommand(fake, "get_state");
+  assert.equal(spawnedCommand, process.execPath);
+  assert.equal(spawnedArgs[0], "/bundled/pi-agent-helper.mjs");
+  assert.ok(spawnedArgs.includes("--mode"));
+  assert.ok(spawnedArgs.includes("rpc"));
+  assert.ok(spawnedArgs.includes("--provider"));
+  assert.ok(spawnedArgs.some((arg) => arg.endsWith("sessions")));
+  assert.ok(spawnedArgs.some((arg) => arg.endsWith("system-prompt.md")));
+  assert.equal(spawnedEnv.PI_PACKAGE_DIR, "/bundled/pi-agent-assets");
+  assert.equal(spawnedEnv.PI_CODING_AGENT_DIR, "/private/pi-builtin-home");
+  assert.equal(spawnedEnv.KITH_PI_API_KEY, "activation-key");
+  assert.equal(spawnedEnv.PI_TELEMETRY, "0");
+  const snapshot = await session.snapshot();
+  assert.equal(snapshot.payload.runtime, "pi-builtin");
+  assert.equal(snapshot.payload.engineSessionId, "builtin-session-1");
+  assert.doesNotMatch(JSON.stringify(snapshot), /must\/not\/persist/);
+  await session.close("shutdown");
+});
+
+test("the built-in Pi runtime completes turns on agent_settled like the external protocol", async () => {
+  const fake = new FakeHelper();
+  const root = mkdtempSync(path.join(os.tmpdir(), "kith-pi-builtin-turn-"));
+  const runtime = createPiBuiltinRpcRuntimeV2("/bundled/pi-agent-helper.mjs", () => fake as unknown as ChildProcess);
+  const session = await runtime.openSession(options(root));
+  const events: any[] = [];
+  const result = session.runTurn({
+    turnId: "turn", attemptId: "attempt", context: "Hello", capabilityActivationId: "activation",
+    deadlineAt: Date.now() + 30_000,
+  }, { emit: async (event) => { events.push(event); } });
+  await waitForCommand(fake, "prompt");
+  fake.line({ type: "agent_start" });
+  fake.line({ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "内置回复" } });
+  fake.line({ type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "内置回复" }],
+    usage: { input: 3, output: 2 } } });
+  fake.line({ type: "agent_settled" });
+  const completed = await result;
+  assert.equal(completed.outcome, "completed");
+  assert.equal(completed.engineSessionId, "builtin-session-1");
+  assert.equal(completed.usage?.inputTokens, 3);
+  assert.ok(events.some((event) => event.kind === "turn_started" && event.payload.runtime === "pi-builtin"));
+  assert.ok(events.some((event) => event.kind === "text_preview" && event.payload.text === "内置回复"));
+  await session.close("shutdown");
+});
+
+test("the built-in Pi runtime restores ELECTRON_RUN_AS_NODE for the packaged Desktop helper", async () => {
+  const fake = new FakeHelper();
+  const root = mkdtempSync(path.join(os.tmpdir(), "kith-pi-builtin-electron-"));
+  let spawnedEnv: NodeJS.ProcessEnv = {};
+  const original = Object.getOwnPropertyDescriptor(process.versions, "electron");
+  Object.defineProperty(process.versions, "electron", { value: "37.0.0", configurable: true });
+  try {
+    const runtime = createPiBuiltinRpcRuntimeV2("/bundled/pi-agent-helper.mjs", (_command, _args, spawnOptions) => {
+      spawnedEnv = spawnOptions.env;
+      return fake as unknown as ChildProcess;
+    });
+    const session = await runtime.openSession(options(root));
+    await waitForCommand(fake, "get_state");
+    assert.equal(spawnedEnv.ELECTRON_RUN_AS_NODE, "1");
+    await session.close("shutdown");
+  } finally {
+    if (original) Object.defineProperty(process.versions, "electron", original);
+    else delete (process.versions as Record<string, unknown>).electron;
+  }
+});
+
+test("piAgentAssetsDir points next to the helper bundle", () => {
+  assert.equal(piAgentAssetsDir("/a/b/pi-agent-helper.mjs"), path.join("/a/b", "pi-agent-assets"));
+});

--- a/src/runtime/adapters/piBuiltinRpcRuntimeV2.ts
+++ b/src/runtime/adapters/piBuiltinRpcRuntimeV2.ts
@@ -1,0 +1,59 @@
+import path from "node:path";
+import type { ChildProcess } from "node:child_process";
+import { spawnRuntimeProcess } from "../../daemon/runtimeProcess.js";
+import { resolvePiAgentHelper } from "../worker/pi-agent/piAgentHelperResolver.js";
+import {
+  createPiRpcRuntimeV2WithSpawn,
+  type PiRpcSpawnOptions,
+} from "./piRpcRuntimeV2.js";
+import type { RuntimeV2 } from "../contract/v2/runtimeContract.js";
+
+type SpawnBuiltin = (command: string, args: string[], options: PiRpcSpawnOptions) => ChildProcess;
+
+/**
+ * Built-in Pi Agent runtime: the same JSONL RPC session as the external
+ * `pi --mode rpc` CLI, but served by the bundled pi-agent-helper (the locked
+ * @earendil-works/pi-coding-agent CLI entry) started through process.execPath.
+ * No locally installed Pi CLI is required.
+ *
+ * The bundled helper still loads Pi's built-in theme JSONs from disk at
+ * startup; PI_PACKAGE_DIR points them at the assets shipped next to the
+ * helper bundle (desktop/dist/runtime/pi-agent-assets).
+ */
+export function piAgentAssetsDir(helperPath: string): string {
+  return path.join(path.dirname(helperPath), "pi-agent-assets");
+}
+
+export function piBuiltinHelperEnvironment(helperPath: string, base: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  return {
+    ...base,
+    PI_PACKAGE_DIR: piAgentAssetsDir(helperPath),
+    // In packaged Desktop the Worker runs under the Electron executable; the
+    // agent env deliberately strips ELECTRON_RUN_AS_NODE, but without it the
+    // helper would boot the full GUI instead of running the script.
+    ELECTRON_RUN_AS_NODE: process.versions.electron ? "1" : undefined,
+  };
+}
+
+export function createPiBuiltinRpcRuntimeV2(
+  helperPath: string = resolvePiAgentHelper(),
+  spawnBuiltin: SpawnBuiltin = (command, args, options) => spawnRuntimeProcess(
+    command,
+    args,
+    options,
+    { rawBytes: true },
+  ),
+  now: () => number = Date.now,
+): RuntimeV2 {
+  return createPiRpcRuntimeV2WithSpawn({
+    fingerprintRuntime: "pi-builtin",
+    eventRuntime: "pi-builtin",
+    spawn: (args, options) => spawnBuiltin(
+      process.execPath,
+      [helperPath, ...args],
+      { ...options, env: piBuiltinHelperEnvironment(helperPath, options.env) },
+    ),
+  }, now);
+}
+
+export const piBuiltinRpcRuntimeV2 = createPiBuiltinRpcRuntimeV2();

--- a/src/runtime/adapters/piRpcRuntimeV2.ts
+++ b/src/runtime/adapters/piRpcRuntimeV2.ts
@@ -27,6 +27,21 @@ type SpawnPi = (command: string, args: string[], options: {
   cwd: string; env: NodeJS.ProcessEnv; stdio: ["pipe", "pipe", "pipe"];
 }) => ChildProcess;
 
+export interface PiRpcSpawnOptions {
+  cwd: string; env: NodeJS.ProcessEnv; stdio: ["pipe", "pipe", "pipe"];
+}
+
+/**
+ * Everything that differs between the external `pi` CLI and the bundled
+ * built-in helper. Both speak the identical JSONL RPC protocol, so the
+ * session state machine and event mapping are fully shared.
+ */
+export interface PiRpcSpawnSpec {
+  fingerprintRuntime: string;
+  eventRuntime: string;
+  spawn(args: string[], options: PiRpcSpawnOptions): ChildProcess;
+}
+
 type ActiveTurn = {
   input: RuntimeTurnInput;
   sink: RuntimeEventSink;
@@ -93,7 +108,7 @@ function assistantText(message: any): string {
     .join("");
 }
 
-function configFingerprint(options: OpenRuntimeSessionOptions): string {
+function configFingerprint(options: OpenRuntimeSessionOptions, fingerprintRuntime: string): string {
   const compiled = options.runtimeConfig?.compiledRuntimeConfiguration;
   const stableRuntimeConfig = compiled && typeof compiled === "object"
     && typeof (compiled as { fingerprint?: unknown }).fingerprint === "string"
@@ -106,7 +121,7 @@ function configFingerprint(options: OpenRuntimeSessionOptions): string {
       reasoningEffort: options.runtimeConfig?.reasoningEffort ?? null,
     };
   return createHash("sha256").update(JSON.stringify({
-    runtime: "pi", model: options.model ?? null, runtimeConfig: stableRuntimeConfig,
+    runtime: fingerprintRuntime, model: options.model ?? null, runtimeConfig: stableRuntimeConfig,
     prompt: options.systemPrompt.digest, cwd: path.resolve(options.cwd),
   })).digest("hex");
 }
@@ -128,16 +143,16 @@ class PiRpcSession implements RuntimeSessionV2 {
 
   constructor(
     private readonly options: OpenRuntimeSessionOptions,
-    private readonly spawnPi: SpawnPi,
+    private readonly spec: PiRpcSpawnSpec,
     private readonly now: () => number,
   ) {
     this.generationRoot = path.join(
       options.runtimeStateDir, "pi-rpc", options.runtimeSessionId, `g${options.sessionGeneration}`,
     );
-    this.fingerprint = configFingerprint(options);
+    this.fingerprint = configFingerprint(options, spec.fingerprintRuntime);
     const restored = options.restoredSnapshot?.adapterSnapshot;
     if (restored?.schemaVersion === 1
-      && restored.payload.runtime === "pi"
+      && restored.payload.runtime === spec.fingerprintRuntime
       && restored.payload.configFingerprint === this.fingerprint
       && validOpaqueSessionId(restored.payload.engineSessionId)
       && restored.payload.resumable === true) {
@@ -157,7 +172,7 @@ class PiRpcSession implements RuntimeSessionV2 {
       input, sink, ordinal: 0, chain: Promise.resolve(), resolve, finished, resolveFinished,
       settled: false, cancelRequested: false, messageStreamedText: "",
     };
-    this.emit("turn_started", { runtime: "pi", protocol: "rpc", mcpMode: "none", gateway: "cli" });
+    this.emit("turn_started", { runtime: this.spec.eventRuntime, protocol: "rpc", mcpMode: "none", gateway: "cli" });
     try {
       const response = await this.command(
         "prompt",
@@ -213,7 +228,7 @@ class PiRpcSession implements RuntimeSessionV2 {
     return {
       schemaVersion: 1,
       payload: {
-        runtime: "pi", adapterSchema: 1, engineSessionId: this.engineSessionId,
+        runtime: this.spec.fingerprintRuntime, adapterSchema: 1, engineSessionId: this.engineSessionId,
         resumable: !this.closed && Boolean(this.engineSessionId), configFingerprint: this.fingerprint,
       },
     };
@@ -263,7 +278,7 @@ class PiRpcSession implements RuntimeSessionV2 {
     };
     if (!this.options.env.PI_CODING_AGENT_DIR) delete env.PI_CODING_AGENT_DIR;
     delete env.NODE_OPTIONS;
-    const child = this.spawnPi("pi", args, { cwd: this.options.cwd, env, stdio: ["pipe", "pipe", "pipe"] });
+    const child = this.spec.spawn(args, { cwd: this.options.cwd, env, stdio: ["pipe", "pipe", "pipe"] });
     this.process = child;
     child.stdout?.on("data", (chunk: Buffer) => this.onStdout(chunk));
     child.stderr?.on("data", () => { /* Drain diagnostics so the child cannot block on a full pipe. */ });
@@ -436,15 +451,26 @@ class PiRpcSession implements RuntimeSessionV2 {
   }
 }
 
+export function createPiRpcRuntimeV2WithSpawn(
+  spec: PiRpcSpawnSpec,
+  now: () => number = Date.now,
+): RuntimeV2 {
+  return {
+    name: spec.eventRuntime,
+    capabilities: PI_RPC_PROTOCOL_BASELINE.capabilities,
+    async openSession(options) { return new PiRpcSession(options, spec, now); },
+  };
+}
+
 export function createPiRpcRuntimeV2(
   spawnPi: SpawnPi = (command, args, options) => spawnRuntimeProcess(command, args, options, { rawBytes: true }),
   now: () => number = Date.now,
 ): RuntimeV2 {
-  return {
-    name: "pi",
-    capabilities: PI_RPC_PROTOCOL_BASELINE.capabilities,
-    async openSession(options) { return new PiRpcSession(options, spawnPi, now); },
-  };
+  return createPiRpcRuntimeV2WithSpawn({
+    fingerprintRuntime: "pi",
+    eventRuntime: "pi",
+    spawn: (args, options) => spawnPi("pi", args, options),
+  }, now);
 }
 
 export const piRpcRuntimeV2 = createPiRpcRuntimeV2();

--- a/src/runtime/adapters/runtimeV2Bridge.ts
+++ b/src/runtime/adapters/runtimeV2Bridge.ts
@@ -17,6 +17,7 @@ import { codexRuntime } from "../../daemon/codexRuntime.js";
 import { opencodeRuntime } from "../../daemon/opencodeRuntime.js";
 import { createLogger } from "../../log.js";
 import { piRpcRuntimeV2 } from "./piRpcRuntimeV2.js";
+import { piBuiltinRpcRuntimeV2 } from "./piBuiltinRpcRuntimeV2.js";
 
 interface ActiveTurn {
   input: RuntimeTurnInput;
@@ -270,5 +271,6 @@ export function getRuntimeV2(name: string): RuntimeV2 | null {
   if (name === "codex") return codexRuntimeV2;
   if (name === "opencode") return opencodeRuntimeV2;
   if (name === "pi") return piRpcRuntimeV2;
+  if (name === "pi-builtin") return piBuiltinRpcRuntimeV2;
   return null;
 }

--- a/src/runtime/adapters/runtimeV2CapabilityMatrix.test.ts
+++ b/src/runtime/adapters/runtimeV2CapabilityMatrix.test.ts
@@ -5,24 +5,28 @@ import { RUNTIME_V2_CAPABILITY_MATRIX } from "./runtimeV2CapabilityMatrix.js";
 
 test("v2 adapters publish honest runtime-specific capabilities without claiming future security gates", () => {
   for (const [runtime, report] of Object.entries(RUNTIME_V2_CAPABILITY_MATRIX)) {
+    const piRpc = runtime === "pi" || runtime === "pi-builtin";
     assert.doesNotThrow(() => RuntimeCapabilitiesSchema.parse(report.capabilities));
-    assert.equal(report.adapterVersion, runtime === "pi" ? "pi-rpc-v1" : "v2-bridge-2");
-    assert.equal(report.capabilityMode, runtime === "pi" ? "cli_gateway" : "mcp_with_cli_fallback");
+    assert.equal(report.adapterVersion, runtime === "pi" ? "pi-rpc-v1"
+      : runtime === "pi-builtin" ? "pi-builtin-rpc-v1" : "v2-bridge-2");
+    assert.equal(report.capabilityMode, piRpc ? "cli_gateway" : "mcp_with_cli_fallback");
     assert.equal(report.support.resume, "observed_v2");
     assert.equal(report.support.sessionChanged, "observed_v2");
     assert.equal(report.support.completion, "observed_v2");
     assert.equal(report.support.cancel, "observed_v2");
-    assert.equal(report.support.mcpBootstrap, runtime === "pi" ? "unsupported" : "fixture_v2");
+    assert.equal(report.support.mcpBootstrap, piRpc ? "unsupported" : "fixture_v2");
     assert.equal(report.support.toolIsolation, "unsupported");
     assert.equal(report.support.cwdRelocation, "unsupported");
     assert.equal(report.capabilities.toolIsolation, "none");
     assert.equal(report.capabilities.cwdRelocatableResume, false);
-    assert.equal(report.capabilities.mcp, runtime === "pi" ? "none" : "config");
+    assert.equal(report.capabilities.mcp, piRpc ? "none" : "config");
   }
   assert.equal(RUNTIME_V2_CAPABILITY_MATRIX.claude.capabilities.persistentProcess, true);
   assert.equal(RUNTIME_V2_CAPABILITY_MATRIX.codex.capabilities.persistentProcess, true);
   assert.equal(RUNTIME_V2_CAPABILITY_MATRIX.opencode.capabilities.persistentProcess, false);
   assert.equal(RUNTIME_V2_CAPABILITY_MATRIX.pi.capabilities.persistentProcess, true);
+  assert.equal(RUNTIME_V2_CAPABILITY_MATRIX["pi-builtin"].capabilities.persistentProcess, true);
+  assert.equal(RUNTIME_V2_CAPABILITY_MATRIX["pi-builtin"].support.compactionTelemetry, "observed_v2");
   assert.equal(RUNTIME_V2_CAPABILITY_MATRIX.pi.support.compactionTelemetry, "observed_v2");
   assert.equal(RUNTIME_V2_CAPABILITY_MATRIX.claude.support.compactionTelemetry, "unsupported");
   assert.equal(RUNTIME_V2_CAPABILITY_MATRIX.codex.support.compactionTelemetry, "fixture_v2");

--- a/src/runtime/adapters/runtimeV2CapabilityMatrix.ts
+++ b/src/runtime/adapters/runtimeV2CapabilityMatrix.ts
@@ -1,6 +1,7 @@
 import type { RuntimeCapabilities } from "../contract/v2/runtimeContract.js";
 import { claudeRuntimeV2, codexRuntimeV2, opencodeRuntimeV2 } from "./runtimeV2Bridge.js";
 import { piRpcRuntimeV2 } from "./piRpcRuntimeV2.js";
+import { piBuiltinRpcRuntimeV2 } from "./piBuiltinRpcRuntimeV2.js";
 
 export type RuntimeV2Support = "fixture_v2" | "observed_v2" | "unsupported";
 
@@ -28,7 +29,7 @@ const commonUnsupported = {
 };
 
 /** P-A10.1 bridge facts. Unsupported capabilities must remain unavailable, never prompt-emulated. */
-export const RUNTIME_V2_CAPABILITY_MATRIX: Record<"claude" | "codex" | "opencode" | "pi", RuntimeV2CapabilityReport> = {
+export const RUNTIME_V2_CAPABILITY_MATRIX: Record<"claude" | "codex" | "opencode" | "pi" | "pi-builtin", RuntimeV2CapabilityReport> = {
   claude: {
     adapterVersion: "v2-bridge-2",
     capabilityMode: "mcp_with_cli_fallback",
@@ -76,6 +77,22 @@ export const RUNTIME_V2_CAPABILITY_MATRIX: Record<"claude" | "codex" | "opencode
     adapterVersion: "pi-rpc-v1",
     capabilityMode: "cli_gateway",
     capabilities: piRpcRuntimeV2.capabilities,
+    support: {
+      resume: "observed_v2",
+      sessionChanged: "observed_v2",
+      usage: "observed_v2",
+      completion: "observed_v2",
+      cancel: "observed_v2",
+      mcpBootstrap: "unsupported",
+      toolIsolation: "unsupported",
+      cwdRelocation: "unsupported",
+      compactionTelemetry: "observed_v2",
+    },
+  },
+  "pi-builtin": {
+    adapterVersion: "pi-builtin-rpc-v1",
+    capabilityMode: "cli_gateway",
+    capabilities: piBuiltinRpcRuntimeV2.capabilities,
     support: {
       resume: "observed_v2",
       sessionChanged: "observed_v2",

--- a/src/runtime/config/runtimeCompilers.ts
+++ b/src/runtime/config/runtimeCompilers.ts
@@ -118,3 +118,41 @@ export class PiRuntimeConfigCompiler extends BaseRuntimeConfigCompiler {
     });
   }
 }
+
+/**
+ * Built-in Pi Agent runtime: the bundled pi-agent-helper speaks the same
+ * `--mode rpc` protocol as the external Pi CLI, so the compiled surface is
+ * identical except that unmanaged CLI-native mode does not exist (the runtime
+ * ships with the app) and a minimal settings.json pins project trust to never.
+ */
+export class PiBuiltinRuntimeConfigCompiler extends BaseRuntimeConfigCompiler {
+  readonly runtimeId = "pi-builtin";
+  private readonly apiKinds = ["anthropic-messages", "openai-responses", "openai-completions", "google-generative-ai", "google-vertex", "bedrock-converse-stream"];
+  describeCapabilities() {
+    const capabilities = base(this.apiKinds, "unsupported");
+    return { ...capabilities, unmanagedCliNative: false };
+  }
+  validate(input: RuntimeConfigurationInput) { return supported(input, this.apiKinds); }
+  async compile(input: RuntimeConfigurationInput, activation: ActivatedRuntimeCredential | null) {
+    this.requireValid(input);
+    const credential = this.credential(activation);
+    const root = await this.privateRoot(input, "pi-builtin");
+    const files = [
+      await this.privateFile(root, "models.json", JSON.stringify({
+        providers: { kith: { baseUrl: input.canonicalOrigin,
+          ...(credential ? { apiKey: "$KITH_PI_API_KEY" } : {}), api: input.apiKind,
+          models: [{ id: input.modelId, name: input.modelId }] } },
+      })),
+      await this.privateFile(root, "settings.json", JSON.stringify({ defaultProjectTrust: "never" })),
+    ];
+    return this.result(input, activation, {
+      args: ["--mode", "rpc", "--provider", "kith", "--model", input.modelId,
+        ...(input.reasoning ? ["--thinking", input.reasoning] : []),
+        "--no-approve", "--no-context-files", "--no-extensions", "--no-skills",
+        "--no-prompt-templates", "--no-themes"],
+      env: { PI_CODING_AGENT_DIR: root, ...(credential ? { KITH_PI_API_KEY: credential } : {}),
+        PI_OFFLINE: "1", PI_TELEMETRY: "0", PI_DISABLE_UPDATE_CHECK: "1", DO_NOT_TRACK: "1" },
+      files, cleanupRoot: root,
+    });
+  }
+}

--- a/src/runtime/config/runtimeConfigCompilerRegistry.test.ts
+++ b/src/runtime/config/runtimeConfigCompilerRegistry.test.ts
@@ -11,10 +11,10 @@ const base = {
   backendId: "openai", providerOptions: {}, compilerPolicyVersion: 1, compilerPolicyDigest: "policy",
 };
 
-test("four managed runtime compilers keep credentials child-only and Pi reports MCP unsupported", async () => {
+test("five managed runtime compilers keep credentials child-only and Pi reports MCP unsupported", async () => {
   const root = mkdtempSync(path.join(os.tmpdir(), "kith-compilers-"));
   const registry = new RuntimeConfigCompilerRegistry();
-  assert.deepEqual(registry.list().map((item) => item.runtimeId), ["claude", "codex", "opencode", "pi"]);
+  assert.deepEqual(registry.list().map((item) => item.runtimeId), ["claude", "codex", "opencode", "pi", "pi-builtin"]);
   const activation = { value: "secret-value", identityDigest: "identity" };
   const claude = await registry.get("claude").compile({
     ...base, runtimeId: "claude", runtimeStateDir: root, apiKind: "anthropic-messages",
@@ -41,6 +41,26 @@ test("four managed runtime compilers keep credentials child-only and Pi reports 
   assert.ok(compiledPi.args.includes("--no-context-files"));
   assert.doesNotMatch(readFileSync(compiledPi.ephemeralFiles[0]!.path, "utf8"), /secret-value/);
   await compiledPi.cleanup();
+  const piBuiltin = registry.get("pi-builtin");
+  const capabilities = piBuiltin.describeCapabilities("test");
+  assert.equal(capabilities.mcpBootstrap, "unsupported");
+  assert.equal(capabilities.unmanagedCliNative, false);
+  const compiledBuiltin = await piBuiltin.compile({
+    ...base, runtimeId: "pi-builtin", runtimeStateDir: root,
+  }, activation);
+  assert.ok(compiledBuiltin.args.includes("--provider"));
+  assert.ok(compiledBuiltin.args.includes("--thinking"));
+  assert.equal(compiledBuiltin.env.PI_CODING_AGENT_DIR?.includes("pi-builtin-"), true);
+  assert.equal(compiledBuiltin.env.PI_OFFLINE, "1");
+  assert.equal(compiledBuiltin.env.PI_TELEMETRY, "0");
+  assert.equal(compiledBuiltin.env.DO_NOT_TRACK, "1");
+  assert.equal(compiledBuiltin.env.KITH_PI_API_KEY, "secret-value");
+  const modelsJson = readFileSync(compiledBuiltin.ephemeralFiles.find((file) => file.path.endsWith("models.json"))!.path, "utf8");
+  assert.match(modelsJson, /KITH_PI_API_KEY/);
+  assert.doesNotMatch(modelsJson, /secret-value/);
+  const settingsJson = readFileSync(compiledBuiltin.ephemeralFiles.find((file) => file.path.endsWith("settings.json"))!.path, "utf8");
+  assert.equal(JSON.parse(settingsJson).defaultProjectTrust, "never");
+  await compiledBuiltin.cleanup();
 });
 
 test("keyless local managed providers omit credential env without weakening activation identity", async () => {

--- a/src/runtime/config/runtimeConfigCompilerRegistry.ts
+++ b/src/runtime/config/runtimeConfigCompilerRegistry.ts
@@ -1,7 +1,8 @@
 import type { RuntimeId } from "../../local-runtime/runtimeCatalog.js";
 import type { RuntimeConfigCompiler } from "./runtimeConfigCompiler.js";
 import {
-  ClaudeRuntimeConfigCompiler, CodexRuntimeConfigCompiler, OpenCodeRuntimeConfigCompiler, PiRuntimeConfigCompiler,
+  ClaudeRuntimeConfigCompiler, CodexRuntimeConfigCompiler, OpenCodeRuntimeConfigCompiler,
+  PiRuntimeConfigCompiler, PiBuiltinRuntimeConfigCompiler,
 } from "./runtimeCompilers.js";
 
 export class RuntimeConfigCompilerRegistry {
@@ -10,6 +11,7 @@ export class RuntimeConfigCompilerRegistry {
   constructor(compilers: readonly RuntimeConfigCompiler[] = [
     new ClaudeRuntimeConfigCompiler(), new CodexRuntimeConfigCompiler(),
     new OpenCodeRuntimeConfigCompiler(), new PiRuntimeConfigCompiler(),
+    new PiBuiltinRuntimeConfigCompiler(),
   ]) {
     for (const compiler of compilers) {
       if (this.compilers.has(compiler.runtimeId)) throw new Error(`duplicate runtime compiler: ${compiler.runtimeId}`);

--- a/src/runtime/worker/pi-agent/piAgentHelperEntry.ts
+++ b/src/runtime/worker/pi-agent/piAgentHelperEntry.ts
@@ -1,0 +1,17 @@
+import { main } from "@earendil-works/pi-coding-agent";
+
+// Kith-owned entry for the built-in Pi Agent runtime. This is the locked
+// @earendil-works/pi-coding-agent CLI entry (the `rpc-entry` equivalent)
+// invoked through process.execPath by the Local Runtime Worker, so the JSONL
+// RPC protocol is byte-for-byte the one the external `pi --mode rpc` CLI
+// speaks. `main` configures the HTTP dispatcher and telemetry itself.
+//
+// All configuration arrives through process argv/env prepared by
+// PiBuiltinRuntimeConfigCompiler plus the session-level env of the adapter
+// (PI_CODING_AGENT_DIR points at the per-session private root, never the
+// user's real ~/.pi/agent).
+process.env.PI_CODING_AGENT = "true";
+process.env.AI_AGENT = "pi";
+// RPC stdout is the protocol channel; diagnostics must not leak into it.
+process.emitWarning = (() => {});
+void main(["--mode", "rpc", ...process.argv.slice(2)]);

--- a/src/runtime/worker/pi-agent/piAgentHelperResolver.ts
+++ b/src/runtime/worker/pi-agent/piAgentHelperResolver.ts
@@ -1,0 +1,18 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const PI_AGENT_HELPER_NAME = "pi-agent-helper.mjs";
+
+/**
+ * Resolve the bundled built-in Pi Agent helper. In the bundled Worker the
+ * helper is a sibling of the worker entry; in the source tree the dev build
+ * output under desktop/dist/runtime is used instead (same contract as
+ * resolvePiAdvisorHelper in src/runtime/worker/maintenance/piSdkAdvisorProvider.ts).
+ */
+export function resolvePiAgentHelper(): string {
+  const explicit = process.env.KITH_SPACE_PI_AGENT_HELPER;
+  if (explicit) return path.resolve(explicit);
+  const sibling = fileURLToPath(new URL(`./${PI_AGENT_HELPER_NAME}`, import.meta.url));
+  if (!sibling.includes(`${path.sep}src${path.sep}`)) return sibling;
+  return path.resolve(process.cwd(), "desktop", "dist", "runtime", PI_AGENT_HELPER_NAME);
+}

--- a/src/runtime/worker/sessions/runtimeSessionPreparation.ts
+++ b/src/runtime/worker/sessions/runtimeSessionPreparation.ts
@@ -194,7 +194,8 @@ export async function prepareRuntimeSession(input: {
   try { await access(memory.agent.indexFile); }
   catch { await writeFile(memory.agent.indexFile, seedMemory(input.config.displayName || input.config.name, input.config.description)); }
   const here = path.dirname(fileURLToPath(import.meta.url));
-  let gateway = input.config.runtime === "pi"
+  const piRuntime = input.config.runtime === "pi" || input.config.runtime === "pi-builtin";
+  let gateway = piRuntime
     ? {
       capabilityMode: "cli_only" as const,
       cliAvailable: true,
@@ -210,7 +211,7 @@ export async function prepareRuntimeSession(input: {
       sessionId: input.record.id,
       electron: !!process.versions.electron,
     });
-  if (input.config.runtime !== "pi") gateway = await verifyRuntimeGatewayLaunch(gateway);
+  if (!piRuntime) gateway = await verifyRuntimeGatewayLaunch(gateway);
   const systemText = buildHarnessV2SystemPrompt({
     name: input.config.name,
     displayName: input.config.displayName,

--- a/src/server/routes-api/agentOnboarding.ts
+++ b/src/server/routes-api/agentOnboarding.ts
@@ -1,0 +1,16 @@
+import { AgentOnboardingService } from "../../personal-setup/agentOnboardingService.js";
+import { sendJson } from "../util.js";
+import type { HumanCtx } from "./ctx.js";
+
+const onboarding = new AgentOnboardingService();
+
+/** One-time Agent creation wizard gate, installation-level (human scope). */
+export function handleAgentOnboarding(ctx: HumanCtx): boolean {
+  if (ctx.p === "/api/setup/agent-onboarding" && ctx.method === "GET") {
+    return (sendJson(ctx.res, 200, onboarding.status()), true);
+  }
+  if (ctx.p === "/api/setup/agent-onboarding/complete" && ctx.method === "POST") {
+    return (sendJson(ctx.res, 200, onboarding.complete()), true);
+  }
+  return false;
+}

--- a/src/server/routes-api/index.ts
+++ b/src/server/routes-api/index.ts
@@ -25,6 +25,7 @@ import { handleHumanAttachmentGet, handleAttachments } from "./attachments.js";
 import { handleAuthenticatedBrowserAuth, handleDesktopBrowserAccess, handlePublicBrowserAuth } from "./browserAccess.js";
 import { handleDesktopSettings } from "./desktopSettings.js";
 import { handlePersonalSetup } from "./setup.js";
+import { handleAgentOnboarding } from "./agentOnboarding.js";
 import { handleSpacesHumanScope } from "./spaces.js";
 import { handleLocalRuntimeHumanScope } from "./localRuntime.js";
 import { handleSpacePreferences } from "./spacePreferences.js";
@@ -66,6 +67,7 @@ export async function handleApi(req: IncomingMessage, res: ServerResponse, url: 
   const humanId = auth.humanId;
   const humanCtx: HumanCtx = { ...base, humanId };
   if (await handleAuthenticatedBrowserAuth(base, auth)) return true;
+  if (await handleAgentOnboarding(humanCtx)) return true;
   if (await handleHumanAttachmentGet(humanCtx)) return true;
   if (await handleHumanProfile(humanCtx)) return true;
   if (await handleHostDirectories(humanCtx)) return true;

--- a/src/server/routes-api/modelSettings.ts
+++ b/src/server/routes-api/modelSettings.ts
@@ -10,6 +10,8 @@ import { RuntimeProfileService } from "../../model-control/runtimeProfileService
 import { SettingsPresentationService } from "../../model-control/settingsPresentationService.js";
 import { AdvisorBindingService } from "../../model-control/advisorBindingService.js";
 import { CliConfigImportService } from "../../model-control/cliConfigImportService.js";
+import { PiConfigModelImportService, piAgentConfigRoot } from "../../model-control/piConfigModelImportService.js";
+import { listPiSdkCatalog } from "../../advisor-provider/piSdkCatalog.js";
 import { readJson, sendErr, sendJson } from "../util.js";
 import type { HumanCtx } from "./ctx.js";
 import { workerRuntimes } from "../../local-runtime/workerHub.js";
@@ -151,6 +153,7 @@ export async function handleModelSettings(ctx: HumanCtx): Promise<boolean> {
   const presenter = new SettingsPresentationService();
   const advisor = new AdvisorBindingService();
   const cliImports = new CliConfigImportService(runtimes);
+  const piModelImports = new PiConfigModelImportService(providers, configurations);
   const runtimeSetup = new RuntimeSetupService(undefined, runtimes);
   try {
     if (ctx.p === "/api/settings/model-providers" && ctx.method === "GET") {
@@ -306,8 +309,71 @@ export async function handleModelSettings(ctx: HumanCtx): Promise<boolean> {
       sendJson(ctx.res, 200, await cliImports.apply(body.runtimeId, body.sourceMtimeDigest));
       return true;
     }
+    if (ctx.p === "/api/settings/pi-presets" && ctx.method === "GET") {
+      const byProvider = new Map<string, {
+        backendId: string;
+        apiKind: string;
+        canonicalOrigin: string;
+        models: Array<{ id: string; name: string; thinkingLevels: readonly string[] }>;
+      }>();
+      for (const item of listPiSdkCatalog()) {
+        const existing = byProvider.get(item.backendId);
+        const model = { id: item.modelId, name: item.modelId, thinkingLevels: item.thinkingLevels };
+        if (existing) existing.models.push(model);
+        else byProvider.set(item.backendId, {
+          backendId: item.backendId,
+          apiKind: item.apiKind,
+          canonicalOrigin: item.canonicalOrigin,
+          models: [model],
+        });
+      }
+      const providers = [...byProvider.values()]
+        .sort((left, right) => left.backendId.localeCompare(right.backendId))
+        .map((provider) => ({
+          ...provider,
+          models: provider.models.sort((left, right) => left.id.localeCompare(right.id)),
+        }));
+      sendJson(ctx.res, 200, { providers });
+      return true;
+    }
+    if (ctx.p === "/api/settings/pi-config-import/preview" && ctx.method === "POST") {
+      if (!isDesktopTrustedRequest(ctx.req)) throw new ModelControlError("desktop_trust_required");
+      sendJson(ctx.res, 200, piModelImports.preview());
+      return true;
+    }
+    if (ctx.p === "/api/settings/pi-config-import/apply" && ctx.method === "POST") {
+      if (!isDesktopTrustedRequest(ctx.req)) throw new ModelControlError("desktop_trust_required");
+      // The import root is fixed to the user's Pi CLI config directory; callers
+      // cannot redirect the read to an arbitrary path.
+      const body = z.object({
+        sourceMtimeDigest: z.string().length(64),
+      }).strict().parse(await readJson(ctx.req));
+      sendJson(ctx.res, 200, await piModelImports.apply(piAgentConfigRoot(), body.sourceMtimeDigest));
+      return true;
+    }
     const runtimeSetupMatch = /^\/api\/settings\/runtimes\/([^/]+)\/setup$/.exec(ctx.p);
     if (runtimeSetupMatch) {
+      if (runtimeSetupMatch[1] === "pi-builtin") {
+        // The built-in Pi Agent ships with the app: nothing to install or probe.
+        if (ctx.method === "GET") {
+          sendJson(ctx.res, 200, {
+            runtimeId: "pi-builtin",
+            label: "Pi Agent（内置）",
+            summary: "随 Kith-space 内置的 Pi Agent 运行时，无需安装或登录。",
+            installation: {
+              state: "installed", source: null, version: null, executablePath: null,
+              testedVersion: "builtin",
+            },
+            account: { state: "ready", label: "随应用内置", help: "", loginCommand: "" },
+            managedInstall: {
+              packageName: "", canInstall: false, canRemove: false, restartRequiredAfterChange: true,
+            },
+          });
+          return true;
+        }
+        sendErr(ctx.res, 409, "内置运行时无需安装或卸载", { code: "runtime_setup_unavailable" });
+        return true;
+      }
       const runtimeId = z.enum(SETUP_RUNTIME_IDS).parse(runtimeSetupMatch[1]) as SetupRuntimeId;
       if (ctx.method === "GET") {
         sendJson(ctx.res, 200, await runtimeSetup.inspect(runtimeId));
@@ -325,6 +391,12 @@ export async function handleModelSettings(ctx: HumanCtx): Promise<boolean> {
     }
     const runtimeMatch = /^\/api\/settings\/runtimes\/([^/]+)$/.exec(ctx.p);
     const runtimeProbeMatch = /^\/api\/settings\/runtimes\/([^/]+)\/probe$/.exec(ctx.p);
+    if (runtimeProbeMatch && ctx.method === "POST" && runtimeProbeMatch[1] === "pi-builtin") {
+      // Nothing to probe: the built-in runtime ships with the app. Return the
+      // profile so the settings page can refresh its default binding.
+      sendJson(ctx.res, 200, runtimes.get("pi-builtin"));
+      return true;
+    }
     if (runtimeProbeMatch && ctx.method === "POST") {
       const runtimeId = z.enum(SETUP_RUNTIME_IDS).parse(runtimeProbeMatch[1]) as SetupRuntimeId;
       const setup = await runtimeSetup.inspect(runtimeId, true);

--- a/src/turns/turnScheduler.ts
+++ b/src/turns/turnScheduler.ts
@@ -622,7 +622,7 @@ export class HarnessTurnScheduler {
 }
 
 function isSupportedRuntime(runtime: string | undefined): runtime is keyof typeof RUNTIME_V2_CAPABILITY_MATRIX {
-  return runtime === "claude" || runtime === "codex" || runtime === "opencode" || runtime === "pi";
+  return runtime === "claude" || runtime === "codex" || runtime === "opencode" || runtime === "pi" || runtime === "pi-builtin";
 }
 
 function sessionDescriptor(session: RuntimeSessionRecord, snapshot: RuntimeSessionSnapshot | null) {

--- a/test/appDatabaseMigration.unit.test.ts
+++ b/test/appDatabaseMigration.unit.test.ts
@@ -41,7 +41,28 @@ function removeV8AppearanceSettings(sqlite: Database.Database): void {
   `);
 }
 
+function removeV14PiBuiltinCompatBackfill(sqlite: Database.Database): void {
+  sqlite.exec(`
+    DELETE FROM app_migration_journal WHERE version >= 14;
+  `);
+  sqlite.pragma("user_version = 13");
+}
+
+function removeV13PiBuiltinRuntime(sqlite: Database.Database): void {
+  sqlite.pragma("foreign_keys = OFF");
+  sqlite.exec(`
+    DELETE FROM runtime_profiles WHERE runtime_id = 'pi-builtin';
+    DELETE FROM runtime_profile_revisions WHERE runtime_id = 'pi-builtin';
+  `);
+  sqlite.pragma("foreign_keys = ON");
+  sqlite.exec(`
+    ALTER TABLE installation_state DROP COLUMN agent_onboarding_completed_at;
+    DELETE FROM app_migration_journal WHERE version >= 13;
+  `);
+}
+
 function removeV12GenerationProvidersAudio(sqlite: Database.Database): void {
+  removeV13PiBuiltinRuntime(sqlite);
   sqlite.exec(`
     DROP INDEX IF EXISTS generation_providers_name_uniq;
     CREATE TABLE generation_providers__v11 (
@@ -66,6 +87,7 @@ function removeV12GenerationProvidersAudio(sqlite: Database.Database): void {
 }
 
 function removeV11GenerationProviders(sqlite: Database.Database): void {
+  removeV13PiBuiltinRuntime(sqlite);
   sqlite.exec(`
     DROP TABLE IF EXISTS generation_providers;
     DELETE FROM app_migration_journal WHERE version >= 11;
@@ -198,6 +220,8 @@ test("fresh app.db migrates transactionally to the versioned installation baseli
       { version: 10, name: "appearance-color-mode", checksumLength: 64 },
       { version: 11, name: "generation-providers", checksumLength: 64 },
       { version: 12, name: "generation-providers-audio", checksumLength: 64 },
+      { version: 13, name: "pi-builtin-runtime-and-agent-onboarding", checksumLength: 64 },
+      { version: 14, name: "pi-builtin-model-compat-backfill", checksumLength: 64 },
     ]);
     assert.match(String(sqlite.prepare("SELECT content_hmac_key FROM installation_state WHERE singleton_key = 1").pluck().get()), /^[0-9a-f]{64}$/);
     for (const table of [
@@ -278,7 +302,12 @@ test("fresh app.db migrates transactionally to the versioned installation baseli
       { runtime_id: "codex", default_binding_mode: "unset", default_model_configuration_id: null, default_model_configuration_revision: null },
       { runtime_id: "opencode", default_binding_mode: "unset", default_model_configuration_id: null, default_model_configuration_revision: null },
       { runtime_id: "pi", default_binding_mode: "unset", default_model_configuration_id: null, default_model_configuration_revision: null },
+      { runtime_id: "pi-builtin", default_binding_mode: "unset", default_model_configuration_id: null, default_model_configuration_revision: null },
     ]);
+    assert.equal(sqlite.prepare(`
+      SELECT agent_onboarding_completed_at
+      FROM installation_state WHERE singleton_key = 1
+    `).pluck().get(), null);
     assert.throws(() => sqlite.prepare(`
       UPDATE runtime_profiles
       SET default_binding_mode = 'kith_model_configuration',
@@ -400,6 +429,48 @@ test("version 11 app.db rebuilds generation provider checks for OpenRouter audio
       sqlite.prepare("SELECT type FROM generation_providers WHERE name = 'openrouter'").pluck().get(),
       "audio",
     );
+  });
+});
+
+test("pre-existing v13 model configurations receive the pi-builtin compatibility key", () => {
+  withAppDatabase((sqlite, dbPath) => {
+    migrateAppDatabase(sqlite, dbPath);
+    // Rewind to v13 and plant a legacy model configuration whose compatibility
+    // snapshot only knows the four pre-builtin runtimes.
+    removeV14PiBuiltinCompatBackfill(sqlite);
+    sqlite.pragma("foreign_keys = OFF");
+    sqlite.exec(`
+      INSERT INTO model_provider_connections (id, display_name, status, current_revision, created_at, updated_at)
+        VALUES ('legacy-provider', 'Legacy', 'active', 1, 1, 1);
+      INSERT INTO model_provider_connection_revisions (
+        connection_id, revision, backend_id, api_kind, canonical_origin, network_class,
+        credential_source_kind, credential_ref, credential_identity_digest, data_policy_revision,
+        data_policy_provenance, allowed_egress_json, capability_snapshot_json, source_kind,
+        source_snapshot_digest, created_at
+      ) VALUES ('legacy-provider', 1, 'openai', 'openai-responses', 'https://api.openai.com', 'public_cloud',
+        'keyless_local', NULL, '', 'v1', 'human_asserted', '[]', '{}', 'manual', 'legacy', 1);
+      INSERT INTO model_configurations (id, display_name, status, current_revision, created_at, updated_at)
+        VALUES ('legacy-model', 'Legacy Model', 'active', 1, 1, 1);
+      INSERT INTO model_configuration_revisions (
+        configuration_id, revision, provider_connection_id, provider_revision, model_id,
+        reasoning, context_window, max_output_tokens, input_capabilities_json,
+        runtime_compatibility_snapshot_json, options_json, created_at
+      ) VALUES ('legacy-model', 1, 'legacy-provider', 1, 'gpt-legacy', NULL, NULL, NULL, '["text"]',
+        '{"claude":{"supported":false,"reason":"wire_api_not_supported"},"codex":{"supported":true},"opencode":{"supported":true},"pi":{"supported":true}}',
+        '{}', 1);
+    `);
+    sqlite.pragma("foreign_keys = ON");
+
+    migrateAppDatabase(sqlite, dbPath);
+
+    const snapshot = JSON.parse(sqlite.prepare(
+      "SELECT runtime_compatibility_snapshot_json FROM model_configuration_revisions WHERE configuration_id = 'legacy-model'",
+    ).pluck().get() as string);
+    assert.equal(snapshot["pi-builtin"]?.supported, true);
+    assert.equal(snapshot.claude?.supported, false);
+    assert.equal(snapshot.claude?.reason, "wire_api_not_supported");
+    assert.equal(snapshot.codex?.supported, true);
+    assert.equal(snapshot.pi?.supported, true);
   });
 });
 

--- a/web/src/agentOnboarding.ts
+++ b/web/src/agentOnboarding.ts
@@ -1,0 +1,147 @@
+export interface AgentOnboardingStatus {
+  pending: boolean;
+  completedAt: number | null;
+  homeSpaceId: string | null;
+  homeAgentCount: number;
+}
+
+export interface OnboardingRuntime {
+  id: string;
+  label: string;
+  installed: boolean;
+  builtIn?: boolean;
+}
+
+export interface OnboardingPresetProvider {
+  backendId: string;
+  apiKind: string;
+  canonicalOrigin: string;
+  models: Array<{ id: string; name: string; thinkingLevels: readonly string[] }>;
+}
+
+export interface OnboardingPiImportProvider {
+  backendId: string;
+  apiKind: string;
+  canonicalOrigin: string;
+  models: Array<{ id: string; name: string }>;
+  credential: { kind: string };
+  warnings: string[];
+}
+
+export interface OnboardingModelConfiguration {
+  id: string;
+  displayName: string;
+  status: string;
+  currentRevision: number;
+  modelId: string;
+  provider: { id: string; displayName: string; backendId: string };
+  compatibility: Record<string, { supported: boolean } | undefined>;
+}
+
+export async function createOnboardingAgent(api: Api, input: OnboardingAgentDraft): Promise<any> {
+  return api("POST", "/api/agents", {
+    name: input.name,
+    displayName: input.displayName,
+    description: input.description,
+    runtime: input.runtime,
+    model: null,
+    modelBinding: input.modelBinding,
+    reasoning: null,
+    fastMode: input.fastMode,
+  });
+}
+
+export interface OnboardingAgentDraft {
+  name: string;
+  displayName: string;
+  description: string;
+  runtime: string;
+  modelBinding:
+    | { mode: "runtime_default" }
+    | { mode: "pinned"; modelConfigurationId: string; modelConfigurationRevision: number };
+  fastMode: boolean;
+}
+
+type Api = (method: string, path: string, body?: unknown) => Promise<any>;
+
+export async function loadAgentOnboardingStatus(api: Api): Promise<AgentOnboardingStatus> {
+  return api("GET", "/api/setup/agent-onboarding");
+}
+
+export async function completeAgentOnboarding(api: Api): Promise<AgentOnboardingStatus> {
+  return api("POST", "/api/setup/agent-onboarding/complete");
+}
+
+export async function loadOnboardingRuntimes(api: Api): Promise<OnboardingRuntime[]> {
+  const result = await api("GET", "/api/local-runtime/runtimes");
+  return (result?.runtimes ?? []) as OnboardingRuntime[];
+}
+
+export async function loadOnboardingPresets(api: Api): Promise<OnboardingPresetProvider[]> {
+  const result = await api("GET", "/api/settings/pi-presets");
+  return (result?.providers ?? []) as OnboardingPresetProvider[];
+}
+
+export async function loadOnboardingModelConfigurations(api: Api): Promise<OnboardingModelConfiguration[]> {
+  const result = await api("GET", "/api/settings/model-configurations");
+  return (result?.items ?? []) as OnboardingModelConfiguration[];
+}
+
+/**
+ * Create a provider connection + model configuration in one aggregated save
+ * (same server transaction as the model settings editor), returning the model
+ * configuration id and revision for a runtime default binding.
+ */
+export async function createOnboardingModel(api: Api, input: {
+  displayName: string;
+  backendId: string;
+  apiKind: string;
+  canonicalOrigin: string;
+  credentialValue?: string;
+  modelId: string;
+}): Promise<{ configurationId: string; configurationRevision: number }> {
+  let parsed: URL;
+  try {
+    parsed = new URL(input.canonicalOrigin);
+  } catch {
+    throw new Error("API 地址无效");
+  }
+  const origin = parsed.origin + parsed.pathname.replace(/\/$/, "");
+  const provider = {
+    displayName: input.displayName || input.backendId,
+    backendId: input.backendId,
+    apiKind: input.apiKind,
+    canonicalOrigin: origin,
+    networkClass: ["127.0.0.1", "localhost", "::1"].includes(parsed.hostname) ? "loopback" : "public_cloud",
+    credentialSourceKind: input.credentialValue ? "kith_secret" : "keyless_local",
+    ...(input.credentialValue ? { credentialValue: input.credentialValue } : {}),
+    dataPolicyRevision: "human-confirmed-v1",
+    dataPolicyProvenance: "human_asserted",
+    allowedEgress: [origin],
+    capabilitySnapshot: {},
+  };
+  const result = await api("POST", "/api/settings/model-provider-bundles", {
+    provider,
+    models: [{ displayName: input.modelId, modelId: input.modelId }],
+  });
+  const created = result?.models?.[0];
+  if (!created?.configuration?.id || !created?.revision?.revision) {
+    throw new Error("模型创建失败：服务端没有返回模型配置");
+  }
+  return { configurationId: created.configuration.id, configurationRevision: created.revision.revision };
+}
+
+export async function bindRuntimeDefaultModel(api: Api, input: {
+  runtimeId: string;
+  configurationId: string;
+  configurationRevision: number;
+}): Promise<void> {
+  await api("PATCH", `/api/settings/runtimes/${encodeURIComponent(input.runtimeId)}`, {
+    enabled: true,
+    defaultBinding: {
+      mode: "kith_model_configuration",
+      modelConfigurationId: input.configurationId,
+      modelConfigurationRevision: input.configurationRevision,
+    },
+  });
+}

--- a/web/src/personalAgentOsContract.test.ts
+++ b/web/src/personalAgentOsContract.test.ts
@@ -35,7 +35,12 @@ test("Machine and Computers are absent from the frontend product surface", () =>
   );
   assert.match(modules, /\{ id: "search",[^\n]+sidebar: false \}/);
   assert.match(runtimeDiscovery, /\/api\/local-runtime\/models\/\$\{runtime\}/);
-  assert.match(agents, /api\("POST", "\/api\/agents", \{ name:/);
+  // Agent creation moved into the shared creation wizard; the contract keeps
+  // requiring that Members still owns the entry point and that creation goes
+  // through the store api against POST /api/agents.
+  assert.match(agents, /CreateAgentModal/);
+  const agentCreation = source("./agentOnboarding.ts");
+  assert.match(agentCreation, /api\("POST", "\/api\/agents", \{\s*name: input\.name,/);
 });
 
 test("Human membership, invite, and profile surfaces are absent", () => {

--- a/web/src/shell/WorkspaceFrame.tsx
+++ b/web/src/shell/WorkspaceFrame.tsx
@@ -10,6 +10,8 @@ import {
 } from "../components/ui/sidebar.tsx";
 import { TooltipProvider } from "../components/ui/tooltip.tsx";
 import { useStore } from "../store.tsx";
+import { loadAgentOnboardingStatus, type AgentOnboardingStatus } from "../agentOnboarding.ts";
+import { AgentCreationWizard } from "../views/AgentCreationWizard.tsx";
 import { ChannelSettingsPanel } from "../views/channel-settings/index.ts";
 import { ConversationAggregatePanel } from "../views/conversation-aggregate/ConversationAggregatePanel.tsx";
 import { LiveTrace } from "../views/LiveTrace.tsx";
@@ -106,6 +108,7 @@ export function WorkspaceFrame() {
   const [workspaceWidth, setWorkspaceWidth] = useState(() => typeof window === "undefined" ? 1280 : window.innerWidth);
   const [aggregateOpen, setAggregateOpen] = useState(true);
   const [quickSwitcherOpen, setQuickSwitcherOpen] = useState(false);
+  const [onboarding, setOnboarding] = useState<AgentOnboardingStatus | null>(null);
   const [aggregateTransitioning, setAggregateTransitioning] = useState(false);
   const [sidebarTransitioning, setSidebarTransitioning] = useState(false);
   const [workspaceExpanded, setWorkspaceExpanded] = useState(false);
@@ -163,6 +166,17 @@ export function WorkspaceFrame() {
   const layoutState = workspaceLayoutForSpace(requestedLayoutState, isHome);
   const { activeModule } = layoutState;
   const settingsOpen = activeModule === "settings";
+
+  // One-time Agent creation wizard: only in the Home space, only while the
+  // installation-level onboarding gate is still pending.
+  useEffect(() => {
+    if (!isHome) return;
+    let cancelled = false;
+    loadAgentOnboardingStatus(api)
+      .then((status) => { if (!cancelled) setOnboarding(status); })
+      .catch(() => { if (!cancelled) setOnboarding(null); });
+    return () => { cancelled = true; };
+  }, [api, isHome]);
   const routeContentModuleId = activeModule && activeModule !== "settings"
     ? activeModule as ContentModuleId
     : null;
@@ -677,6 +691,13 @@ export function WorkspaceFrame() {
             />
           ) : null}
           {quickSwitcherOpen ? <QuickSwitcher onClose={() => setQuickSwitcherOpen(false)} /> : null}
+          {isHome && onboarding?.pending ? (
+            <AgentCreationWizard
+              api={api}
+              mode="onboarding"
+              onClose={() => setOnboarding((current) => current ? { ...current, pending: false } : current)}
+            />
+          ) : null}
         </section>
         </SidebarInset>
       </SidebarProvider>

--- a/web/src/views/AgentCreationWizard.css
+++ b/web/src/views/AgentCreationWizard.css
@@ -1,0 +1,284 @@
+.onboarding-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 90;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: rgb(15 16 18 / 45%);
+  backdrop-filter: blur(3px);
+}
+
+.onboarding-modal {
+  width: min(560px, 100%);
+  max-height: min(720px, calc(100vh - 48px));
+  overflow: hidden;
+  border: 1px solid #e2e3e6;
+  border-radius: 16px;
+  background: #fff;
+  box-shadow: 0 24px 64px rgb(0 0 0 / 22%);
+  display: flex;
+  flex-direction: column;
+}
+
+.onboarding-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 20px 22px 14px;
+}
+
+.onboarding-header h2 { margin: 2px 0 4px; font-size: 19px; }
+.onboarding-header p { margin: 0; color: #6b6e76; font-size: 13px; line-height: 1.5; }
+
+.onboarding-eyebrow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0;
+  color: #8a5a12;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.onboarding-icon-button {
+  border: 0;
+  border-radius: 8px;
+  padding: 7px;
+  background: transparent;
+  color: #6b6e76;
+  cursor: pointer;
+  align-self: flex-start;
+}
+.onboarding-icon-button:hover { background: #f1f2f4; color: #232428; }
+
+.onboarding-steps {
+  display: flex;
+  gap: 6px;
+  margin: 0;
+  padding: 0 22px 14px;
+  list-style: none;
+  border-bottom: 1px solid #ececef;
+}
+
+.onboarding-steps li {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #9a9ca3;
+}
+
+.onboarding-steps li.current { color: #232428; }
+.onboarding-steps li.done { color: #3f7d4d; }
+
+.onboarding-step-dot {
+  display: grid;
+  place-items: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #ececef;
+  font-size: 11px;
+}
+.onboarding-steps li.current .onboarding-step-dot { background: #232428; color: #fff; }
+.onboarding-steps li.done .onboarding-step-dot { background: #3f7d4d; color: #fff; }
+
+.onboarding-body { flex: 1; min-height: 0; overflow-y: auto; padding: 18px 22px; }
+.onboarding-body h3 { margin: 0 0 4px; font-size: 15px; }
+
+.onboarding-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  border-top: 1px solid #ececef;
+  padding: 14px 22px;
+  background: #fff;
+  flex-shrink: 0;
+}
+
+.onboarding-hint { margin: 0 0 14px; color: #6b6e76; font-size: 13px; line-height: 1.5; }
+.onboarding-muted { margin: 0 0 10px; color: #6b6e76; font-size: 12px; line-height: 1.5; overflow-wrap: anywhere; }
+
+/* Selected-runtime detail card shown under the dropdown. */
+.onboarding-runtime-card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  margin-top: 10px;
+  border: 1px solid #232428;
+  border-radius: 12px;
+  padding: 12px 14px;
+  background: #fff;
+  text-align: left;
+  box-shadow: 0 0 0 2px rgb(35 36 40 / 10%);
+}
+
+.onboarding-runtime-logo {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 9px;
+  background: #f1f2f4;
+  color: #232428;
+}
+
+.onboarding-runtime-main { flex: 1; display: grid; gap: 2px; }
+.onboarding-runtime-main strong { font-size: 13px; }
+.onboarding-runtime-main small { color: #9a9ca3; font-size: 11px; }
+
+.onboarding-badge {
+  border-radius: 999px;
+  padding: 3px 9px;
+  background: #eaf6ee;
+  color: #3f7d4d;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.onboarding-tabs { display: flex; gap: 4px; margin-bottom: 14px; border-bottom: 1px solid #ececef; }
+.onboarding-tabs button {
+  border: 0;
+  border-bottom: 2px solid transparent;
+  padding: 8px 12px;
+  background: transparent;
+  color: #6b6e76;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.onboarding-tabs button.active { border-bottom-color: #232428; color: #232428; }
+
+.onboarding-model-panel { display: grid; gap: 12px; margin-bottom: 14px; }
+
+.onboarding-field { display: grid; gap: 5px; font-size: 12px; font-weight: 600; color: #232428; }
+.onboarding-field span small { color: #9a9ca3; font-weight: 400; }
+.onboarding-field input,
+.onboarding-field select,
+.onboarding-field textarea {
+  width: 100%;
+  border: 1px solid #d6d7db;
+  border-radius: 9px;
+  padding: 9px 11px;
+  font-size: 13px;
+  font-family: inherit;
+  color: #232428;
+  background: #fff;
+}
+.onboarding-field input:focus,
+.onboarding-field select:focus,
+.onboarding-field textarea:focus { outline: none; border-color: #4c4d51; box-shadow: 0 0 0 3px rgb(32 33 36 / 9%); }
+.onboarding-field textarea { resize: vertical; }
+
+.onboarding-secret-field { display: flex; align-items: center; gap: 8px; }
+.onboarding-secret-field svg { color: #9a9ca3; flex-shrink: 0; }
+.onboarding-secret-field input { flex: 1; }
+
+.onboarding-import-empty {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border: 1px dashed #d6d7db;
+  border-radius: 10px;
+  padding: 14px;
+  color: #6b6e76;
+  font-size: 12px;
+}
+.onboarding-import-empty p { margin: 0; line-height: 1.5; }
+
+/* Create-mode: follow-the-runtime-default card shown above the model tabs. */
+.onboarding-default-follow { display: grid; gap: 8px; margin-bottom: 12px; }
+
+.onboarding-follow-card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  border: 1px solid #e2e3e6;
+  border-radius: 12px;
+  padding: 10px 14px;
+  background: #fff;
+  text-align: left;
+  cursor: pointer;
+}
+.onboarding-follow-card:hover:not(:disabled) { border-color: #b9bac0; }
+.onboarding-follow-card.selected { border-color: #232428; box-shadow: 0 0 0 2px rgb(35 36 40 / 10%); }
+.onboarding-follow-card:disabled { opacity: 0.55; cursor: not-allowed; }
+.onboarding-follow-card .onboarding-runtime-logo { width: 30px; height: 30px; }
+
+.onboarding-fast-row {
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+  margin-top: 12px;
+  font-weight: 400;
+}
+.onboarding-fast-row input { width: auto; }
+
+.onboarding-warnings { margin: 0; padding-left: 18px; display: grid; gap: 3px; color: #8a5a12; font-size: 12px; }
+
+.onboarding-error {
+  margin: 0 0 10px;
+  border-radius: 9px;
+  padding: 9px 12px;
+  background: #fdf0ef;
+  color: #8c3a33;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.onboarding-success {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin: 0 0 10px;
+  border-radius: 9px;
+  padding: 9px 12px;
+  background: #eaf6ee;
+  color: #2f6b3c;
+  font-size: 12px;
+}
+
+.onboarding-model-actions { display: flex; justify-content: flex-end; }
+
+.onboarding-summary {
+  display: grid;
+  gap: 6px;
+  border: 1px solid #ececef;
+  border-radius: 10px;
+  padding: 12px 14px;
+  background: #fafafa;
+}
+.onboarding-summary p { display: flex; align-items: center; gap: 8px; margin: 0; font-size: 13px; color: #4a4c52; }
+.onboarding-summary svg { color: #3f7d4d; }
+
+.onboarding-footer__right { display: flex; gap: 8px; }
+
+.onboarding-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid #d6d7db;
+  border-radius: 9px;
+  padding: 9px 14px;
+  background: #fff;
+  color: #232428;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.onboarding-button:hover { background: #f6f7f8; }
+.onboarding-button:disabled { opacity: 0.55; cursor: not-allowed; }
+
+.onboarding-button--primary { border-color: #232428; background: #232428; color: #fff; }
+.onboarding-button--primary:hover { background: #3c3d42; }
+
+@media (prefers-reduced-motion: reduce) {
+  .onboarding-backdrop { backdrop-filter: none; }
+}

--- a/web/src/views/AgentCreationWizard.tsx
+++ b/web/src/views/AgentCreationWizard.tsx
@@ -1,0 +1,732 @@
+import { useEffect, useMemo, useState } from "react";
+import { Bot, Check, ChevronLeft, ChevronRight, KeyRound, Server, Sparkles, Upload, X } from "lucide-react";
+import { useStore } from "../store.tsx";
+import { useToast } from "../toast.tsx";
+import {
+  bindRuntimeDefaultModel,
+  completeAgentOnboarding,
+  createOnboardingAgent,
+  createOnboardingModel,
+  loadOnboardingModelConfigurations,
+  loadOnboardingPresets,
+  loadOnboardingRuntimes,
+  type OnboardingModelConfiguration,
+  type OnboardingPiImportProvider,
+  type OnboardingPresetProvider,
+  type OnboardingRuntime,
+} from "../agentOnboarding.ts";
+import "./AgentCreationWizard.css";
+
+interface AgentCreationWizardProps {
+  api: (method: string, path: string, body?: unknown) => Promise<any>;
+  onClose(): void;
+  /** onboarding: 首次进入 Home 的一次性向导；create: Agents 页面的常规创建弹窗。 */
+  mode: "onboarding" | "create";
+  prefill?: { name?: string; description?: string };
+  onCreated?: (r: { id: string; name: string }) => void;
+}
+
+type ModelConfigTab = "existing" | "preset" | "import" | "manual";
+
+type ModelChoice =
+  | { kind: "runtime_default"; label: string }
+  | { kind: "pinned"; configurationId: string; configurationRevision: number; label: string };
+
+const API_KIND_LABELS: Record<string, string> = {
+  "openai-responses": "OpenAI Responses",
+  "openai-completions": "OpenAI 兼容接口",
+  "anthropic-messages": "Anthropic Messages",
+  "google-generative-ai": "Google Generative AI",
+};
+
+/** 与 src/model-control/modelConfigurationService.ts 的 SUPPORTED 保持同步（未知 apiKind 回退到 Pi 家族）。 */
+const API_KIND_RUNTIMES: Record<string, readonly string[]> = {
+  "anthropic-messages": ["claude", "opencode", "pi", "pi-builtin"],
+  "openai-responses": ["codex", "opencode", "pi", "pi-builtin"],
+  "openai-completions": ["opencode", "pi", "pi-builtin"],
+  "google-generative-ai": ["opencode", "pi", "pi-builtin"],
+};
+
+const V2_RUNTIMES = new Set(["claude", "codex", "opencode", "pi", "pi-builtin"]);
+
+const STEPS = ["选择运行时", "配置模型", "创建 Agent"];
+
+const DRAFT_KEY = "kith-agent-create-draft";
+
+export function AgentCreationWizard({ api, onClose, mode, prefill, onCreated }: AgentCreationWizardProps) {
+  const isCreate = mode === "create";
+  const storeReload = useStore().reload;
+  const toast = useToast();
+  const [step, setStep] = useState(0);
+  const [runtimes, setRuntimes] = useState<OnboardingRuntime[]>([]);
+  const [runtimesLoading, setRuntimesLoading] = useState(true);
+  const [runtimeId, setRuntimeId] = useState("");
+  const [runtimeError, setRuntimeError] = useState("");
+
+  const [presets, setPresets] = useState<OnboardingPresetProvider[]>([]);
+  const [presetsLoading, setPresetsLoading] = useState(false);
+  const [presetsRequested, setPresetsRequested] = useState(false);
+  const [presetProviderId, setPresetProviderId] = useState("");
+  const [presetModelId, setPresetModelId] = useState("");
+  const [presetKey, setPresetKey] = useState("");
+
+  const [modelTab, setModelTab] = useState<ModelConfigTab>(isCreate ? "existing" : "preset");
+  const [existingModels, setExistingModels] = useState<OnboardingModelConfiguration[]>([]);
+  const [existingModelId, setExistingModelId] = useState("");
+  const [runtimeDefaultLabel, setRuntimeDefaultLabel] = useState<string | null>(null);
+  const [runtimeDefaultLoading, setRuntimeDefaultLoading] = useState(false);
+  const [piImport, setPiImport] = useState<{
+    providers: OnboardingPiImportProvider[];
+    warnings: string[];
+    sourceMtimeDigest: string;
+  } | null>(null);
+  const [piImportLoading, setPiImportLoading] = useState(false);
+  const [piImportError, setPiImportError] = useState("");
+  const [importSelection, setImportSelection] = useState<{ providerId: string; modelId: string } | null>(null);
+
+  const [manualDraft, setManualDraft] = useState({
+    displayName: "",
+    backendId: "",
+    apiKind: "openai-completions",
+    canonicalOrigin: "",
+    credentialValue: "",
+    modelId: "",
+  });
+
+  const [modelBusy, setModelBusy] = useState("");
+  const [modelError, setModelError] = useState("");
+  const [modelChoice, setModelChoice] = useState<ModelChoice | null>(null);
+
+  const [agentDraft, setAgentDraft] = useState({
+    name: prefill?.name ?? (isCreate ? "" : "assistant"),
+    displayName: prefill?.name ?? (isCreate ? "" : "助手"),
+    description: prefill?.description ?? "",
+  });
+  const [fast, setFast] = useState(false);
+  const [agentBusy, setAgentBusy] = useState(false);
+  const [agentError, setAgentError] = useState("");
+
+  const selectedRuntimeIsV2 = V2_RUNTIMES.has(runtimeId);
+
+  useEffect(() => {
+    let cancelled = false;
+    loadOnboardingRuntimes(api)
+      .then((available) => {
+        if (cancelled) return;
+        const ordered = [...available].sort((left, right) =>
+          Number(right.builtIn ?? false) - Number(left.builtIn ?? false));
+        setRuntimes(ordered);
+        const draftRuntime = isCreate
+          ? JSON.parse(sessionStorage.getItem(DRAFT_KEY) ?? "null")?.runtime
+          : null;
+        const preferred = (typeof draftRuntime === "string"
+          ? ordered.find((item) => item.id === draftRuntime && item.installed)
+          : undefined)
+          ?? ordered.find((item) => item.id === "pi-builtin" && item.installed)
+          ?? ordered.find((item) => item.installed);
+        setRuntimeId(preferred?.id ?? "");
+        setRuntimeError(preferred ? "" : "没有检测到可用的运行时");
+      })
+      .catch(() => { if (!cancelled) setRuntimeError("无法检测本机运行时"); })
+      .finally(() => { if (!cancelled) setRuntimesLoading(false); });
+    if (isCreate) {
+      try {
+        const saved = JSON.parse(sessionStorage.getItem(DRAFT_KEY) ?? "null");
+        if (saved) {
+          setAgentDraft((current) => ({
+            name: prefill?.name ?? (typeof saved.name === "string" && saved.name ? saved.name : current.name),
+            displayName: prefill?.name ?? (typeof saved.displayName === "string" && saved.displayName ? saved.displayName : current.displayName),
+            description: prefill?.description ?? (typeof saved.description === "string" ? saved.description : current.description),
+          }));
+        }
+      } catch { /* ignore stale draft */ }
+    }
+    return () => { cancelled = true; };
+  }, [api, isCreate, prefill?.name, prefill?.description]);
+
+  useEffect(() => {
+    if (isCreate) {
+      sessionStorage.setItem(DRAFT_KEY, JSON.stringify({
+        name: agentDraft.name, displayName: agentDraft.displayName, description: agentDraft.description, runtime: runtimeId,
+      }));
+    }
+  }, [agentDraft, isCreate, runtimeId]);
+
+  // The create flow needs the existing model configurations for both the
+  // "follow runtime default" hint and the "pick an existing model" tab.
+  useEffect(() => {
+    if (!isCreate || step !== 1) return;
+    let cancelled = false;
+    setExistingModels([]);
+    setExistingModelId("");
+    loadOnboardingModelConfigurations(api)
+      .then((items) => { if (!cancelled) setExistingModels(items.filter((item) => item.status !== "disabled")); })
+      .catch(() => { if (!cancelled) setModelError("无法读取已有模型配置"); });
+    return () => { cancelled = true; };
+  }, [api, isCreate, step, runtimeId]);
+
+  // Runtime-default state drives the "follow default" option in create mode.
+  useEffect(() => {
+    if (!isCreate || step !== 1 || !runtimeId) return;
+    if (!selectedRuntimeIsV2) {
+      setRuntimeDefaultLabel(null);
+      return;
+    }
+    let cancelled = false;
+    setRuntimeDefaultLoading(true);
+    void api("GET", `/api/settings/runtimes/${encodeURIComponent(runtimeId)}`)
+      .then(async (profile: any) => {
+        const binding = profile?.defaultBinding;
+        if (binding?.mode === "kith_model_configuration" && binding.modelConfigurationId) {
+          const configurations = existingModels.length ? existingModels : await loadOnboardingModelConfigurations(api);
+          const match = configurations.find((item) => item.id === binding.modelConfigurationId);
+          if (!cancelled) setRuntimeDefaultLabel(match ? `${match.displayName} · ${match.provider.backendId}` : "已配置（模型已删除）");
+        } else if (!cancelled) {
+          setRuntimeDefaultLabel(null);
+        }
+      })
+      .catch(() => { if (!cancelled) setRuntimeDefaultLabel(null); })
+      .finally(() => { if (!cancelled) setRuntimeDefaultLoading(false); });
+    return () => { cancelled = true; };
+  }, [api, existingModels, isCreate, runtimeId, selectedRuntimeIsV2, step]);
+
+  useEffect(() => {
+    if (step !== 1 || modelTab !== "preset" || presetsRequested) return;
+    setPresetsRequested(true);
+    setPresetsLoading(true);
+    loadOnboardingPresets(api)
+      .then((items) => {
+        setPresets(items);
+        const preferred = items.find((item) => item.backendId === "deepseek") ?? items[0];
+        if (preferred) setPresetProviderId(preferred.backendId);
+      })
+      .catch(() => setModelError("无法读取 Pi 官方预设，请改用其他方式配置模型。"))
+      .finally(() => setPresetsLoading(false));
+  }, [api, modelTab, presetsRequested, step]);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
+
+  // In create mode the presets list is filtered to the selected runtime's
+  // wire-API support; unknown api kinds fall back to the Pi family, matching
+  // computeRuntimeCompatibility on the server.
+  const presetOptions = useMemo(() => {
+    if (!isCreate) return presets;
+    return presets.filter((provider) =>
+      (API_KIND_RUNTIMES[provider.apiKind] ?? ["pi", "pi-builtin"]).includes(runtimeId));
+  }, [isCreate, presets, runtimeId]);
+
+  const selectedPresetProvider = presetOptions.find((item) => item.backendId === presetProviderId)
+    ?? (isCreate ? undefined : presets.find((item) => item.backendId === presetProviderId));
+  const selectedPresetModel = selectedPresetProvider?.models.find((item) => item.id === presetModelId);
+
+  const existingModelOptions = useMemo(
+    () => existingModels.filter((item) => item.compatibility?.[runtimeId]?.supported),
+    [existingModels, runtimeId],
+  );
+  const selectedExistingModel = existingModelOptions.find((item) => item.id === existingModelId);
+
+  const startPiImportPreview = () => {
+    setPiImportError("");
+    setPiImportLoading(true);
+    setPiImport(null);
+    void api("POST", "/api/settings/pi-config-import/preview", {})
+      .then((result) => {
+        setPiImport(result as any);
+        const first = (result?.providers ?? [])[0] as OnboardingPiImportProvider | undefined;
+        if (first) setImportSelection({ providerId: first.backendId, modelId: first.models[0]?.id ?? "" });
+      })
+      .catch((cause: any) => setPiImportError(cause?.message ?? "无法读取本机 Pi 配置"))
+      .finally(() => setPiImportLoading(false));
+  };
+
+  const finishModelStep = async (configurationId: string, configurationRevision: number, label: string) => {
+    setModelBusy("bind");
+    setModelError("");
+    try {
+      if (isCreate) {
+        // Pin the new configuration to this Agent instead of changing the
+        // runtime-wide default other Agents may already follow.
+        setModelChoice({ kind: "pinned", configurationId, configurationRevision, label });
+      } else {
+        await bindRuntimeDefaultModel(api, { runtimeId, configurationId, configurationRevision });
+        setModelChoice({ kind: "runtime_default", label });
+      }
+    } catch (cause: any) {
+      setModelError(cause?.message ?? "无法把模型设为该运行时的默认配置");
+    } finally {
+      setModelBusy("");
+    }
+  };
+
+  const usePresetModel = async () => {
+    if (!selectedPresetProvider || !selectedPresetModel) return;
+    setModelBusy("preset");
+    setModelError("");
+    try {
+      const created = await createOnboardingModel(api, {
+        displayName: selectedPresetProvider.backendId,
+        backendId: selectedPresetProvider.backendId,
+        apiKind: selectedPresetProvider.apiKind,
+        canonicalOrigin: selectedPresetProvider.canonicalOrigin,
+        ...(presetKey ? { credentialValue: presetKey } : {}),
+        modelId: selectedPresetModel.id,
+      });
+      await finishModelStep(created.configurationId, created.configurationRevision, selectedPresetModel.id);
+    } catch (cause: any) {
+      setModelError(cause?.message ?? "无法保存模型配置");
+    } finally {
+      setModelBusy("");
+    }
+  };
+
+  const useExistingModel = () => {
+    if (!selectedExistingModel) return;
+    setModelChoice({
+      kind: "pinned",
+      configurationId: selectedExistingModel.id,
+      configurationRevision: selectedExistingModel.currentRevision,
+      label: `${selectedExistingModel.displayName} · ${selectedExistingModel.provider.backendId}`,
+    });
+  };
+
+  const applyPiImportAndSelect = async () => {
+    if (!piImport || !importSelection) return;
+    setModelBusy("import");
+    setModelError("");
+    try {
+      await api("POST", "/api/settings/pi-config-import/apply", {
+        sourceMtimeDigest: piImport.sourceMtimeDigest,
+      });
+      const configurations = await loadOnboardingModelConfigurations(api);
+      const match = configurations.find((item) =>
+        item.provider.backendId === importSelection.providerId && item.modelId === importSelection.modelId);
+      if (!match) throw new Error("导入完成，但没有找到所选模型配置");
+      await finishModelStep(match.id, match.currentRevision, importSelection.modelId);
+    } catch (cause: any) {
+      setModelError(cause?.message ?? "Pi 配置导入失败");
+    } finally {
+      setModelBusy("");
+    }
+  };
+
+  const useManualModel = async () => {
+    const draft = manualDraft;
+    if (!draft.backendId.trim() || !draft.canonicalOrigin.trim() || !draft.modelId.trim()) {
+      setModelError("请填写供应商 ID、API 地址和模型 ID");
+      return;
+    }
+    setModelBusy("manual");
+    setModelError("");
+    try {
+      const created = await createOnboardingModel(api, {
+        displayName: draft.displayName.trim() || draft.backendId.trim(),
+        backendId: draft.backendId.trim(),
+        apiKind: draft.apiKind,
+        canonicalOrigin: draft.canonicalOrigin.trim(),
+        ...(draft.credentialValue ? { credentialValue: draft.credentialValue } : {}),
+        modelId: draft.modelId.trim(),
+      });
+      await finishModelStep(created.configurationId, created.configurationRevision, draft.modelId.trim());
+    } catch (cause: any) {
+      setModelError(cause?.message ?? "无法保存模型配置");
+    } finally {
+      setModelBusy("");
+    }
+  };
+
+  const createAgent = async () => {
+    const name = agentDraft.name.trim();
+    if (!/^[A-Za-z][A-Za-z0-9_-]*$/.test(name) || name.length > 64) {
+      setAgentError("名称需以字母开头，仅含字母、数字、- 和 _（最长 64 字符）");
+      return;
+    }
+    setAgentBusy(true);
+    setAgentError("");
+    try {
+      const result = await createOnboardingAgent(api, {
+        name,
+        displayName: agentDraft.displayName.trim() || name,
+        description: agentDraft.description.trim(),
+        runtime: runtimeId,
+        modelBinding: modelChoice?.kind === "pinned"
+          ? {
+            mode: "pinned",
+            modelConfigurationId: modelChoice.configurationId,
+            modelConfigurationRevision: modelChoice.configurationRevision,
+          }
+          : { mode: "runtime_default" },
+        fastMode: fast,
+      });
+      if (result?.error) {
+        setAgentError(result.code === "model_binding_setup_required"
+          ? "所选运行时还没有默认模型，请返回上一步为其指定模型。"
+          : String(result.error));
+        setAgentBusy(false);
+        return;
+      }
+      if (isCreate) {
+        await storeReload();
+        if (result?.started === false) toast.info("Agent 已创建，运行器暂不可用，稍后会自动启动。");
+        onCreated?.({ id: result.id, name: result.name ?? name });
+        sessionStorage.removeItem(DRAFT_KEY);
+      } else {
+        await completeAgentOnboarding(api);
+      }
+      onClose();
+    } catch (cause: any) {
+      setAgentError(cause?.message ?? "无法创建 Agent");
+      setAgentBusy(false);
+    }
+  };
+
+  const skip = async () => {
+    if (mode === "onboarding") {
+      try { await completeAgentOnboarding(api); } catch { /* stay dismissible locally */ }
+    }
+    onClose();
+  };
+
+  const canNext = step === 0
+    ? Boolean(runtimeId)
+    : step === 1
+      ? Boolean(modelChoice) || (isCreate && !selectedRuntimeIsV2)
+      : Boolean(agentDraft.name.trim() && agentDraft.displayName.trim());
+
+  const tabs: Array<[ModelConfigTab, string]> = isCreate
+    ? [["existing", "已有模型"], ["preset", "Pi 官方预设"], ["import", "导入 Pi 配置"], ["manual", "手动填写"]]
+    : [["preset", "Pi 官方预设"], ["import", "导入本地 Pi 配置"], ["manual", "手动填写"]];
+
+  return (
+    <div className="onboarding-backdrop" role="presentation" onClick={skip}>
+      <section className="onboarding-modal" role="dialog" aria-modal="true" aria-labelledby="onboarding-title"
+        onClick={(event) => event.stopPropagation()}>
+        <header className="onboarding-header">
+          <div>
+            <p className="onboarding-eyebrow"><Sparkles size={14} />{isCreate ? "创建 Agent" : "首次引导"}</p>
+            <h2 id="onboarding-title">{isCreate ? "创建 Agent" : "创建你的第一个 Agent"}</h2>
+            <p>{isCreate ? "选择运行时和模型，然后为它命名。" : "即使本机没有安装 Claude Code 等工具，内置的 Pi Agent 也能直接开工。"}</p>
+          </div>
+          <button className="onboarding-icon-button" type="button" aria-label="关闭" onClick={() => void skip()}>
+            <X size={18} />
+          </button>
+        </header>
+
+        <ol className="onboarding-steps" aria-label="步骤">
+          {STEPS.map((label, index) => (
+            <li key={label} className={index < step ? "done" : index === step ? "current" : ""}>
+              <span className="onboarding-step-dot">{index < step ? <Check size={12} /> : index + 1}</span>
+              {label}
+            </li>
+          ))}
+        </ol>
+
+        <div className="onboarding-body">
+          {step === 0 ? (
+            <section>
+              <h3>选择运行时</h3>
+              <p className="onboarding-hint">运行时是 Agent 的执行引擎。内置 Pi Agent 随 Kith-space 一起安装，随时可用。</p>
+              {runtimesLoading ? <p className="onboarding-muted">正在检测本机运行时…</p> : (
+                <>
+                  <label className="onboarding-field"><span>运行时</span>
+                    <select value={runtimeId} onChange={(event) => { setRuntimeId(event.target.value); setModelChoice(null); }}>
+                      {runtimes.map((runtime) => (
+                        <option key={runtime.id} value={runtime.id} disabled={!runtime.installed}>
+                          {runtime.label}{runtime.builtIn ? "（内置）" : runtime.installed ? "" : " — 未安装"}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  {(() => {
+                    const runtime = runtimes.find((item) => item.id === runtimeId);
+                    if (!runtime) return null;
+                    return (
+                      <div className="onboarding-runtime-card selected" aria-live="polite">
+                        <span className="onboarding-runtime-logo"><Bot size={18} /></span>
+                        <span className="onboarding-runtime-main">
+                          <strong>{runtime.label}</strong>
+                          <small>{runtime.installed ? "已可用" : "未安装"}</small>
+                        </span>
+                        {runtime.builtIn ? <span className="onboarding-badge">内置 · 推荐</span> : null}
+                      </div>
+                    );
+                  })()}
+                </>
+              )}
+              {runtimeError ? <p className="onboarding-error" role="alert">{runtimeError}</p> : null}
+            </section>
+          ) : null}
+
+          {step === 1 ? (
+            <section>
+              <h3>配置模型</h3>
+              <p className="onboarding-hint">
+                {isCreate && !selectedRuntimeIsV2
+                  ? "此运行时使用自身的本机配置，无需在这里选择模型。"
+                  : isCreate
+                    ? `为「${runtimes.find((item) => item.id === runtimeId)?.label ?? runtimeId}」选择模型。`
+                    : `为「${runtimes.find((item) => item.id === runtimeId)?.label ?? runtimeId}」选择默认模型。`}
+              </p>
+
+              {isCreate && !selectedRuntimeIsV2 ? (
+                <p className="onboarding-muted">直接进入下一步即可；如需调整，请在对应 CLI 的配置中修改。</p>
+              ) : (
+                <>
+                  {isCreate ? (
+                    <div className="onboarding-default-follow">
+                      <button type="button"
+                        className={`onboarding-follow-card${modelChoice?.kind === "runtime_default" ? " selected" : ""}`}
+                        disabled={runtimeDefaultLoading || !runtimeDefaultLabel}
+                        onClick={() => setModelChoice({ kind: "runtime_default", label: runtimeDefaultLabel! })}>
+                        <span className="onboarding-runtime-logo"><Server size={16} /></span>
+                        <span className="onboarding-runtime-main">
+                          <strong>跟随运行器默认</strong>
+                          <small>{runtimeDefaultLoading ? "检查中…" : runtimeDefaultLabel ?? "尚未设置默认模型"}</small>
+                        </span>
+                        {modelChoice?.kind === "runtime_default" ? <span className="onboarding-badge">已选</span> : null}
+                      </button>
+                      <p className="onboarding-muted">或为这个 Agent 单独指定一个模型：</p>
+                    </div>
+                  ) : null}
+
+                  <div className="onboarding-tabs" role="tablist">
+                    {tabs.map(([value, label]) => (
+                      <button key={value} type="button" role="tab" aria-selected={modelTab === value}
+                        className={modelTab === value ? "active" : ""} onClick={() => { setModelTab(value); setModelChoice(null); }}>
+                        {label}
+                      </button>
+                    ))}
+                  </div>
+
+                  {modelTab === "existing" ? (
+                    <div className="onboarding-model-panel">
+                      <label className="onboarding-field"><span>已有模型配置</span>
+                        <select value={existingModelId} disabled={!existingModelOptions.length}
+                          onChange={(event) => setExistingModelId(event.target.value)}>
+                          <option value="">{existingModelOptions.length ? "选择模型…" : "暂无兼容的模型配置"}</option>
+                          {existingModelOptions.map((item) => (
+                            <option key={item.id} value={item.id}>
+                              {item.displayName} · {item.provider.backendId}
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+                    </div>
+                  ) : null}
+
+                  {modelTab === "preset" ? (
+                    <div className="onboarding-model-panel">
+                      <label className="onboarding-field"><span>供应商</span>
+                        <select value={presetProviderId} disabled={presetsLoading || !presetOptions.length}
+                          onChange={(event) => { setPresetProviderId(event.target.value); setPresetModelId(""); }}>
+                          <option value="">{presetsLoading ? "读取官方预设中…" : presetOptions.length ? "选择供应商" : "暂无兼容预设"}</option>
+                          {presetOptions.map((provider) => (
+                            <option key={provider.backendId} value={provider.backendId}>
+                              {provider.backendId} · {API_KIND_LABELS[provider.apiKind] ?? provider.apiKind}
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+                      <label className="onboarding-field"><span>模型</span>
+                        <select value={presetModelId} disabled={!selectedPresetProvider}
+                          onChange={(event) => setPresetModelId(event.target.value)}>
+                          <option value="">选择模型…</option>
+                          {(selectedPresetProvider?.models ?? []).map((model) => (
+                            <option key={model.id} value={model.id}>{model.id}</option>
+                          ))}
+                        </select>
+                      </label>
+                      <label className="onboarding-field"><span>API Key <small>（可选，可稍后在模型设置中补填）</small></span>
+                        <div className="onboarding-secret-field"><KeyRound size={15} />
+                          <input type="password" autoComplete="off" value={presetKey}
+                            placeholder="留空表示无需密钥或稍后再填"
+                            onChange={(event) => setPresetKey(event.target.value)} />
+                        </div>
+                      </label>
+                      {selectedPresetProvider ? (
+                        <p className="onboarding-muted">将请求发送到 <strong>{selectedPresetProvider.canonicalOrigin}</strong></p>
+                      ) : null}
+                    </div>
+                  ) : null}
+
+                  {modelTab === "import" ? (
+                    <div className="onboarding-model-panel">
+                      {piImport ? (
+                        <>
+                          <p className="onboarding-muted">发现 {piImport.providers.length} 个本机 Pi 配置中的供应商，选择要使用的模型后导入。</p>
+                          <label className="onboarding-field"><span>供应商</span>
+                            <select value={importSelection?.providerId ?? ""}
+                              onChange={(event) => {
+                                const provider = piImport.providers.find((item) => item.backendId === event.target.value);
+                                setImportSelection({ providerId: event.target.value, modelId: provider?.models[0]?.id ?? "" });
+                              }}>
+                              {piImport.providers.map((provider) => (
+                                <option key={provider.backendId} value={provider.backendId}>{provider.backendId}</option>
+                              ))}
+                            </select>
+                          </label>
+                          <label className="onboarding-field"><span>模型</span>
+                            <select value={importSelection?.modelId ?? ""}
+                              onChange={(event) => setImportSelection((current) =>
+                                current ? { ...current, modelId: event.target.value } : current)}>
+                              {(piImport.providers.find((item) => item.backendId === importSelection?.providerId)?.models ?? [])
+                                .map((model) => <option key={model.id} value={model.id}>{model.id}</option>)}
+                            </select>
+                          </label>
+                          {piImport.warnings.length ? (
+                            <ul className="onboarding-warnings">
+                              {piImport.warnings.slice(0, 6).map((warning) => <li key={warning}>{warning}</li>)}
+                            </ul>
+                          ) : null}
+                        </>
+                      ) : (
+                        <div className="onboarding-import-empty">
+                          <Upload size={18} />
+                          <p>读取 ~/.pi/agent 中的供应商、模型与凭据。不会执行命令式凭据，也不会写回任何 Pi 配置。</p>
+                        </div>
+                      )}
+                      {piImportError ? <p className="onboarding-error" role="alert">{piImportError}</p> : null}
+                    </div>
+                  ) : null}
+
+                  {modelTab === "manual" ? (
+                    <div className="onboarding-model-panel">
+                      <label className="onboarding-field"><span>供应商 ID</span>
+                        <input value={manualDraft.backendId} placeholder="例如 my-provider"
+                          onChange={(event) => setManualDraft({ ...manualDraft, backendId: event.target.value })} />
+                      </label>
+                      <label className="onboarding-field"><span>接口类型</span>
+                        <select value={manualDraft.apiKind}
+                          onChange={(event) => setManualDraft({ ...manualDraft, apiKind: event.target.value })}>
+                          {Object.entries(API_KIND_LABELS).map(([value, label]) => (
+                            <option key={value} value={value}>{label}</option>
+                          ))}
+                        </select>
+                      </label>
+                      <label className="onboarding-field"><span>API 地址</span>
+                        <input value={manualDraft.canonicalOrigin} placeholder="https://api.example.com"
+                          onChange={(event) => setManualDraft({ ...manualDraft, canonicalOrigin: event.target.value })} />
+                      </label>
+                      <label className="onboarding-field"><span>API Key <small>（可选）</small></span>
+                        <input type="password" autoComplete="off" value={manualDraft.credentialValue}
+                          placeholder="留空表示无需密钥或稍后再填"
+                          onChange={(event) => setManualDraft({ ...manualDraft, credentialValue: event.target.value })} />
+                      </label>
+                      <label className="onboarding-field"><span>模型 ID</span>
+                        <input value={manualDraft.modelId} placeholder="例如 deepseek-v4-pro"
+                          onChange={(event) => setManualDraft({ ...manualDraft, modelId: event.target.value })} />
+                      </label>
+                    </div>
+                  ) : null}
+
+                  {modelError ? <p className="onboarding-error" role="alert">{modelError}</p> : null}
+                  {modelChoice ? (
+                    <p className="onboarding-success" role="status">
+                      <Check size={14} />
+                      {modelChoice.kind === "runtime_default"
+                        ? <>将跟随运行器默认模型：<strong>{modelChoice.label}</strong></>
+                        : <>将为这个 Agent 固定模型：<strong>{modelChoice.label}</strong>，可以进入下一步。</>}
+                    </p>
+                  ) : (
+                    <div className="onboarding-model-actions">
+                      {modelTab === "existing" ? (
+                        <button className="onboarding-button onboarding-button--primary" type="button"
+                          disabled={Boolean(modelBusy) || !selectedExistingModel} onClick={useExistingModel}>
+                          使用此模型
+                        </button>
+                      ) : null}
+                      {modelTab === "preset" ? (
+                        <button className="onboarding-button onboarding-button--primary" type="button"
+                          disabled={Boolean(modelBusy) || !selectedPresetProvider || !selectedPresetModel}
+                          onClick={() => void usePresetModel()}>
+                          {modelBusy === "preset" ? "保存中…" : modelBusy === "bind" ? "绑定中…" : "使用此模型"}
+                        </button>
+                      ) : null}
+                      {modelTab === "import" ? (
+                        <button className="onboarding-button onboarding-button--primary" type="button"
+                          disabled={Boolean(modelBusy) || piImportLoading || (Boolean(piImport) && !importSelection)}
+                          onClick={() => (piImport ? void applyPiImportAndSelect() : startPiImportPreview())}>
+                          {piImportLoading ? "读取中…" : piImport ? (modelBusy ? "导入中…" : "导入并选择此模型") : "读取本机 Pi 配置"}
+                        </button>
+                      ) : null}
+                      {modelTab === "manual" ? (
+                        <button className="onboarding-button onboarding-button--primary" type="button"
+                          disabled={Boolean(modelBusy)} onClick={() => void useManualModel()}>
+                          {modelBusy === "manual" ? "保存中…" : modelBusy === "bind" ? "绑定中…" : "使用此模型"}
+                        </button>
+                      ) : null}
+                    </div>
+                  )}
+                </>
+              )}
+            </section>
+          ) : null}
+
+          {step === 2 ? (
+            <section>
+              <h3>创建 Agent</h3>
+              <p className="onboarding-hint">{isCreate ? "Agent 将加入当前 Space 的 #all 频道，随时可以 @ 它。" : "Agent 将加入 Home Space 的 #all 频道，随时可以 @ 它。"}</p>
+              <label className="onboarding-field"><span>名称（英文标识）</span>
+                <input value={agentDraft.name} maxLength={64} autoFocus
+                  onChange={(event) => setAgentDraft({ ...agentDraft, name: event.target.value })} />
+              </label>
+              <label className="onboarding-field"><span>显示名称</span>
+                <input value={agentDraft.displayName} maxLength={64}
+                  onChange={(event) => setAgentDraft({ ...agentDraft, displayName: event.target.value })} />
+              </label>
+              <label className="onboarding-field"><span>职责描述 <small>（可选）</small></span>
+                <textarea rows={3} maxLength={3000} value={agentDraft.description}
+                  placeholder="例如：负责整理笔记、起草文档和跟进任务"
+                  onChange={(event) => setAgentDraft({ ...agentDraft, description: event.target.value })} />
+              </label>
+              <div className="onboarding-summary">
+                <p><Server size={14} />运行时：{runtimes.find((item) => item.id === runtimeId)?.label ?? runtimeId}</p>
+                <p><Check size={14} />模型：
+                  {modelChoice?.kind === "pinned"
+                    ? `固定 ${modelChoice.label}`
+                    : modelChoice?.kind === "runtime_default"
+                      ? `跟随运行器默认（${modelChoice.label}）`
+                      : isCreate && !selectedRuntimeIsV2 ? "使用运行时本机配置" : "未选择"}
+                </p>
+              </div>
+              {isCreate ? (
+                <label className="onboarding-field onboarding-fast-row">
+                  <input type="checkbox" checked={fast} onChange={(event) => setFast(event.target.checked)} />
+                  <span>快速模式 <small>（跳过深度思考，更快响应）</small></span>
+                </label>
+              ) : null}
+              {agentError ? <p className="onboarding-error" role="alert">{agentError}</p> : null}
+            </section>
+          ) : null}
+        </div>
+
+        <footer className="onboarding-footer">
+          <button className="onboarding-button" type="button" onClick={() => void skip()}>{isCreate ? "取消" : "稍后再说"}</button>
+          <div className="onboarding-footer__right">
+            {step > 0 ? (
+              <button className="onboarding-button" type="button" onClick={() => setStep((current) => current - 1)}>
+                <ChevronLeft size={15} />上一步
+              </button>
+            ) : null}
+            {step < 2 ? (
+              <button className="onboarding-button onboarding-button--primary" type="button"
+                disabled={!canNext || Boolean(modelBusy)} onClick={() => setStep((current) => current + 1)}>
+                下一步<ChevronRight size={15} />
+              </button>
+            ) : (
+              <button className="onboarding-button onboarding-button--primary" type="button"
+                disabled={!canNext || agentBusy} onClick={() => void createAgent()}>
+                {agentBusy ? "创建中…" : "创建 Agent"}
+              </button>
+            )}
+          </div>
+        </footer>
+      </section>
+    </div>
+  );
+}

--- a/web/src/views/Members.tsx
+++ b/web/src/views/Members.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { lazy, Suspense, useEffect, useState } from "react";
 import {
   Activity,
   Check,
@@ -28,7 +28,6 @@ import { useConfirm, useEscClose } from "../ConfirmModal.tsx";
 import { useToast } from "../toast.tsx";
 import i18n from "../i18n";
 import { mergeWorkspaceSearch, workspaceLocationForModule, workspaceSearchForShellState } from "../shell/workspaceRoute.ts";
-import { useRuntimeDiscovery } from "../useRuntimeDiscovery.ts";
 import { agentStatusLabel } from "../agentStatus.ts";
 import { SearchField } from "../components/SearchField.tsx";
 import { AgentDefaultResponseModeCard } from "./agent-response-mode/AgentDefaultResponseModeCard.tsx";
@@ -627,111 +626,16 @@ function AgentProfileEditModal({ name, displayName, description, onDisplayNameCh
   );
 }
 
+// Lazy-loaded so the wizard's CSS import stays out of the node:test import
+// chain (Chat.tsx imports this module; node cannot parse bare .css imports).
+const AgentCreationWizard = lazy(() => import("./AgentCreationWizard.tsx").then((m) => ({ default: m.AgentCreationWizard })));
+
 export function CreateAgentModal({ onClose, prefill, onCreated }: { onClose: () => void; prefill?: { name?: string; description?: string }; onCreated?: (r: { id: string; name: string }) => void }) {
-  const { t } = useTranslation();
-  const toast = useToast();
-  useEscClose(onClose);
-  const { api, reload } = useStore();
-  const [name, setName] = useState(prefill?.name ?? ""); const [desc, setDesc] = useState(prefill?.description ?? "");
-  const [fast, setFast] = useState(false);
-  const [busy, setBusy] = useState(false); const [err, setErr] = useState("");
-  const [bindingMode, setBindingMode] = useState<"runtime_default" | "pinned">("runtime_default");
-  const [modelConfigurations, setModelConfigurations] = useState<any[]>([]);
-  const [modelConfigurationId, setModelConfigurationId] = useState("");
-  const [runtimeDefaultUnset, setRuntimeDefaultUnset] = useState(false);
-  const {
-    runtime, setRuntime, runtimeOptions, runtimesLoading, runtimeError, runtimeInstalled,
-  } = useRuntimeDiscovery(api, false);
-  useEffect(() => {
-    void api("GET", "/api/settings/model-configurations")
-      .then((result: any) => setModelConfigurations(
-        (result.items ?? []).filter((item: any) => item.status === "active"),
-      ))
-      .catch(() => setModelConfigurations([]));
-  }, [api]);
-  useEffect(() => {
-    if (!runtime) { setRuntimeDefaultUnset(false); return; }
-    let cancelled = false;
-    void api("GET", `/api/settings/runtimes/${encodeURIComponent(runtime)}`)
-      .then((result: any) => {
-        if (!cancelled) setRuntimeDefaultUnset(result?.defaultBinding?.mode === "unset");
-      })
-      .catch(() => { if (!cancelled) setRuntimeDefaultUnset(false); });
-    return () => { cancelled = true; };
-  }, [api, runtime]);
-  useEffect(() => {
-    const saved = sessionStorage.getItem("kith-agent-create-draft");
-    if (!saved) return;
-    try {
-      const value = JSON.parse(saved);
-      if (!prefill?.name && typeof value.name === "string") setName(value.name);
-      if (!prefill?.description && typeof value.description === "string") setDesc(value.description);
-      if (value.bindingMode === "runtime_default" || value.bindingMode === "pinned") setBindingMode(value.bindingMode);
-      if (typeof value.modelConfigurationId === "string") setModelConfigurationId(value.modelConfigurationId);
-    } catch { /* ignore stale draft */ }
-  }, []);
-  useEffect(() => {
-    sessionStorage.setItem("kith-agent-create-draft", JSON.stringify({
-      name, description: desc, runtime, bindingMode, modelConfigurationId,
-    }));
-  }, [bindingMode, desc, modelConfigurationId, name, runtime]);
-  const create = async () => {
-    const nm = name.trim();
-    if (!nm) { setErr(t("members.nameRequired")); return; }
-    if (!/^[A-Za-z][A-Za-z0-9_-]*$/.test(nm) || nm.length > 64) { setErr(t("members.nameInvalid")); return; } // @mention handle must be token-safe; keep regex + length 64 in sync with core.ts AGENT_NAME_RE / MAX_AGENT_NAME
-    if (!runtimeInstalled) { setErr(t("members.runtimeUnavailable")); return; }
-    if (bindingMode === "pinned" && !modelConfigurationId) { setErr("请选择 Kith 模型配置"); return; }
-    if (bindingMode === "runtime_default" && runtimeDefaultUnset) { setErr(t("members.runtimeDefaultUnset")); return; }
-    setBusy(true); setErr("");
-    try {
-      const selectedConfiguration = modelConfigurations.find((item) => item.id === modelConfigurationId);
-      const r = await api("POST", "/api/agents", { name: nm,
-        description: desc.trim() || null, runtime,
-        model: null,
-        modelBinding: bindingMode === "pinned"
-          ? { mode: "pinned", modelConfigurationId, modelConfigurationRevision: selectedConfiguration?.currentRevision ?? 1 }
-          : { mode: "runtime_default" },
-        reasoning: null, fastMode: fast,
-      });
-      if (r?.error) {
-        setErr(r.code === "model_binding_setup_required" ? t("members.modelBindingSetupRequired") : r.error);
-        return;
-      }
-      await reload();
-      if (r?.id) { if (r.started === false) toast.info(t("members.agentCreatedOffline")); onCreated?.({ id: r.id, name: r.name ?? nm }); }
-      sessionStorage.removeItem("kith-agent-create-draft");
-      onClose();
-    } catch (e: any) { setErr(String(e?.message || e)); } finally { setBusy(false); }
-  };
+  const { api } = useStore();
   return (
-    <div className="modal-bg" onClick={onClose}>
-      <div className="modal" onClick={(e) => e.stopPropagation()}>
-        <h3>{t("members.createAgentTitle")}</h3>
-        <label>{t("members.nameLabel")}</label><input value={name} maxLength={64} onChange={(e) => setName(e.target.value)} placeholder={t("members.namePlaceholder")} />
-        <label>{t("members.descriptionLabel")}</label><textarea value={desc} maxLength={3000} onChange={(e) => setDesc(e.target.value)} placeholder={t("members.descriptionPlaceholder")} />
-        <label>Runtime</label>
-        <fieldset disabled={runtimesLoading} style={{ border: 0, padding: 0, margin: 0, opacity: runtimesLoading ? 0.6 : 1 }}>
-          <Select ariaLabel="Runtime" value={runtime} options={runtimeOptions} onChange={setRuntime} placeholder={runtimesLoading ? t("members.detectingRuntimes") : undefined} />
-        </fieldset>
-        {runtimeError && <div className="form-err">{runtimeError}</div>}
-        <label>模型绑定</label>
-        <Select ariaLabel="模型绑定方式" value={bindingMode} onChange={(value) => setBindingMode(value as "runtime_default" | "pinned")}
-          options={[
-            { value: "runtime_default", label: "跟随运行器默认配置" },
-            { value: "pinned", label: "固定 Kith 模型配置" },
-          ]} />
-        {bindingMode === "pinned" ? <>
-          <label>Kith 模型配置</label>
-          <Select ariaLabel="Kith 模型配置" value={modelConfigurationId} onChange={setModelConfigurationId}
-            options={modelConfigurations.filter((item) => item.compatibility?.[runtime]?.supported)
-              .map((item) => ({ value: item.id, label: `${item.displayName} · ${item.provider.displayName}` }))}
-            placeholder="请先在“设置 → 模型与供应商”创建兼容配置" />
-        </> : runtimeDefaultUnset ? <div className="form-err">{t("members.runtimeDefaultUnset")}</div> : null}
-        <label className="ck-row"><input type="checkbox" checked={fast} onChange={(e) => setFast(e.target.checked)} /><span>{t("members.fastMode")}</span></label>
-        {err && <div className="form-err">{err}</div>}
-        <div className="acts"><button className="cancel" onClick={onClose}>{t("members.cancel")}</button><button className="ok" onClick={create} disabled={busy || runtimesLoading || !runtimeInstalled || (bindingMode === "pinned" && !modelConfigurationId) || (bindingMode === "runtime_default" && runtimeDefaultUnset)}>{busy ? t("members.creating") : t("members.create")}</button></div>
-      </div>
-    </div>
+    <Suspense fallback={null}>
+      <AgentCreationWizard api={api} mode="create" prefill={prefill} onCreated={onCreated} onClose={onClose} />
+    </Suspense>
   );
 }
 

--- a/web/src/views/model-settings/ModelProviderSettings.tsx
+++ b/web/src/views/model-settings/ModelProviderSettings.tsx
@@ -38,6 +38,12 @@ const PROVIDER_PRESETS = {
     apiKind: "openai-completions",
     canonicalOrigin: "https://api.deepseek.com",
   },
+  pi: {
+    label: "Pi 官方预设",
+    backendId: "",
+    apiKind: "",
+    canonicalOrigin: "",
+  },
   custom: {
     label: "自定义",
     backendId: "custom",
@@ -45,6 +51,22 @@ const PROVIDER_PRESETS = {
     canonicalOrigin: "",
   },
 } as const;
+
+interface PiPresetProvider {
+  backendId: string;
+  apiKind: string;
+  canonicalOrigin: string;
+  models: Array<{ id: string; name: string; thinkingLevels: readonly string[] }>;
+}
+
+interface PiImportProvider {
+  backendId: string;
+  apiKind: string;
+  canonicalOrigin: string;
+  models: Array<{ id: string; name: string }>;
+  credential: { kind: string };
+  warnings: string[];
+}
 
 type ProviderPreset = keyof typeof PROVIDER_PRESETS;
 type ProviderDraft = {
@@ -139,6 +161,16 @@ export function ModelProviderSettings({ api }: { api: Api }) {
   const [notice, setNotice] = useState("");
   const [busy, setBusy] = useState("");
   const [importing, setImporting] = useState<string | null>(null);
+  const [piPresets, setPiPresets] = useState<PiPresetProvider[]>([]);
+  const [piPresetsLoading, setPiPresetsLoading] = useState(false);
+  const [piPresetProvider, setPiPresetProvider] = useState("");
+  const [piPresetModel, setPiPresetModel] = useState("");
+  const [piImport, setPiImport] = useState<{
+    providers: PiImportProvider[];
+    warnings: string[];
+    sourceMtimeDigest: string;
+  } | null>(null);
+  const [piImporting, setPiImporting] = useState(false);
   const dialogRef = useRef<HTMLElement | null>(null);
   const firstFieldRef = useRef<HTMLInputElement | null>(null);
   const dialogTrigger = useRef<HTMLElement | null>(null);
@@ -214,6 +246,20 @@ export function ModelProviderSettings({ api }: { api: Api }) {
   const applyPreset = (value: ProviderPreset) => {
     const next = PROVIDER_PRESETS[value];
     setPreset(value);
+    if (value === "pi") {
+      setDraft({ displayName: "", backendId: "", apiKind: "", canonicalOrigin: "", credentialValue: "" });
+      setModelDrafts([]);
+      setPiPresetProvider("");
+      setPiPresetModel("");
+      if (!piPresets.length && !piPresetsLoading) {
+        setPiPresetsLoading(true);
+        void request("GET", "/api/settings/pi-presets")
+          .then((result) => setPiPresets((result.providers ?? []) as PiPresetProvider[]))
+          .catch(() => setDialogError("无法读取 Pi 官方预设，请稍后重试。"))
+          .finally(() => setPiPresetsLoading(false));
+      }
+      return;
+    }
     setDraft({
       displayName: next.label === "自定义" ? "" : next.label,
       backendId: next.backendId,
@@ -221,6 +267,33 @@ export function ModelProviderSettings({ api }: { api: Api }) {
       canonicalOrigin: next.canonicalOrigin,
       credentialValue: "",
     });
+  };
+
+  const piPresetProviders = piPresets;
+  const selectedPiPresetProvider = piPresets.find((item) => item.backendId === piPresetProvider);
+
+  const applyPiPresetProvider = (backendId: string) => {
+    setPiPresetProvider(backendId);
+    setPiPresetModel("");
+    const provider = piPresets.find((item) => item.backendId === backendId);
+    if (!provider) return;
+    setDraft({
+      displayName: provider.backendId,
+      backendId: provider.backendId,
+      apiKind: provider.apiKind,
+      canonicalOrigin: provider.canonicalOrigin,
+      credentialValue: "",
+    });
+  };
+
+  const addPiPresetModel = () => {
+    if (!piPresetModel || !selectedPiPresetProvider) return;
+    const model = selectedPiPresetProvider.models.find((item) => item.id === piPresetModel);
+    if (!model) return;
+    setModelDrafts((current) => current.some((item) => item.modelId === model.id)
+      ? current
+      : [...current, { key: crypto.randomUUID(), displayName: model.name, modelId: model.id }]);
+    setPiPresetModel("");
   };
 
   const openCreate = (trigger: HTMLElement) => {
@@ -352,6 +425,40 @@ export function ModelProviderSettings({ api }: { api: Api }) {
     }
   };
 
+  const previewPiImport = async () => {
+    setError("");
+    setNotice("");
+    setPiImporting(true);
+    setPiImport(null);
+    try {
+      const preview = await request("POST", "/api/settings/pi-config-import/preview", {});
+      setPiImport(preview as any);
+    } catch (cause: any) {
+      setError(cause?.message ?? "无法读取本机 Pi 配置");
+    } finally {
+      setPiImporting(false);
+    }
+  };
+
+  const applyPiImport = async () => {
+    if (!piImport) return;
+    setPiImporting(true);
+    try {
+      const result = await request("POST", "/api/settings/pi-config-import/apply", {
+        sourceMtimeDigest: piImport.sourceMtimeDigest,
+      });
+      await reload();
+      setPiImport(null);
+      setNotice(result.applied
+        ? `已从本机 Pi 配置导入 ${result.applied} 个模型供应商；原 Pi 配置文件没有被修改。`
+        : "没有可导入的新供应商，已导入过的会被跳过。");
+    } catch (cause: any) {
+      setError(cause?.message ?? "Pi 配置导入失败");
+    } finally {
+      setPiImporting(false);
+    }
+  };
+
   return (
     <div className="model-settings model-settings--wide" data-testid="model-provider-settings">
       <header className="settings-page-heading settings-page-heading--models">
@@ -452,6 +559,52 @@ export function ModelProviderSettings({ api }: { api: Api }) {
         </div>
       </details>
 
+      <details className="settings-import-panel">
+        <summary><Upload size={17} />导入本机 Pi-Agent 的模型配置</summary>
+        <p>
+          读取 <code>~/.pi/agent/models.json</code> 与 <code>auth.json</code> 中的供应商、模型与凭据，保存为 Kith 模型来源；
+          不会执行命令式凭据、复合环境插值或写回任何 Pi 配置。密钥随导入存储在本机，请确认目标地址后再导入。
+        </p>
+        {piImport ? (
+          <div className="pi-import-summary" role="status">
+            <p>发现 {piImport.providers.length} 个可导入供应商：</p>
+            <ul>
+              {piImport.providers.map((provider) => (
+                <li key={provider.backendId}>
+                  <strong>{provider.backendId}</strong> · {provider.apiKind} · {provider.canonicalOrigin} ·{" "}
+                  {provider.models.length} 个模型 · 凭据：
+                  {provider.credential.kind === "pi_cli_auth" ? "使用 Pi 已登录凭据"
+                    : provider.credential.kind === "literal" ? "来自配置文件"
+                    : provider.credential.kind === "env_ref" ? "来自环境变量"
+                    : "未导入（可稍后手动填写）"}
+                </li>
+              ))}
+            </ul>
+            {piImport.warnings.length ? (
+              <ul className="pi-import-warnings">
+                {piImport.warnings.slice(0, 8).map((warning) => <li key={warning}>{warning}</li>)}
+              </ul>
+            ) : null}
+            <div className="settings-actions">
+              <button className="settings-button settings-button--secondary" type="button"
+                disabled={piImporting} onClick={() => setPiImport(null)}>取消</button>
+              <button className="settings-button settings-button--primary" type="button"
+                disabled={piImporting || piImport.providers.length === 0}
+                onClick={() => void applyPiImport()}>
+                {piImporting ? "导入中…" : "确认导入"}
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className="settings-actions">
+            <button className="settings-button settings-button--secondary" type="button"
+              disabled={!desktop || piImporting} onClick={() => void previewPiImport()}>
+              {piImporting ? "读取中…" : "读取本机 Pi 配置"}
+            </button>
+          </div>
+        )}
+      </details>
+
       {showDialog ? (
         <div className="settings-modal-backdrop" role="presentation" onMouseDown={() => setShowDialog(false)}>
           <section className="settings-modal settings-modal--provider" role="dialog" aria-modal="true"
@@ -479,6 +632,38 @@ export function ModelProviderSettings({ api }: { api: Api }) {
                   ))}
                 </select>
               </label>
+              {preset === "pi" ? (
+                <section className="provider-dialog-pi-preset">
+                  <label className="settings-field"><span>Pi 预设供应商</span>
+                    <select value={piPresetProvider}
+                      disabled={piPresetsLoading || !piPresets.length}
+                      onChange={(event) => applyPiPresetProvider(event.target.value)}>
+                      <option value="">{piPresetsLoading ? "读取官方预设中…" : piPresets.length ? "选择供应商" : "暂无可用预设"}</option>
+                      {piPresetProviders.map((item) => (
+                        <option key={item.backendId} value={item.backendId}>
+                          {item.backendId} · {item.models.length} 个官方模型
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  {selectedPiPresetProvider ? (
+                    <div className="settings-field settings-field--row">
+                      <select value={piPresetModel} onChange={(event) => setPiPresetModel(event.target.value)}
+                        aria-label="选择预设模型">
+                        <option value="">选择模型…</option>
+                        {selectedPiPresetProvider.models.map((model) => (
+                          <option key={model.id} value={model.id}>{model.id}</option>
+                        ))}
+                      </select>
+                      <button className="settings-button settings-button--secondary" type="button"
+                        disabled={!piPresetModel} onClick={addPiPresetModel}>
+                        <Plus size={15} />加入列表
+                      </button>
+                    </div>
+                  ) : null}
+                  <p className="provider-dialog-hint">来自锁定版本 Pi 的官方模型目录；选择供应商后添加你需要的模型。</p>
+                </section>
+              ) : null}
               <label className="settings-field"><span>接口类型</span>
                 <select value={draft.apiKind} onChange={(event) => setDraft({ ...draft, apiKind: event.target.value })}>
                   {API_KINDS.map(([value, label]) => <option key={value} value={value}>{label}</option>)}

--- a/web/src/views/model-settings/RuntimeSettings.tsx
+++ b/web/src/views/model-settings/RuntimeSettings.tsx
@@ -16,13 +16,14 @@ import { copyText } from "../../clipboard.ts";
 import "./modelSettings.css";
 
 type Api = (method: string, path: string, body?: unknown) => Promise<any>;
-type RuntimeId = "claude" | "codex" | "opencode" | "pi";
+type RuntimeId = "claude" | "codex" | "opencode" | "pi" | "pi-builtin";
 
-const RUNTIMES: Array<{ id: RuntimeId; label: string; icon: typeof Bot }> = [
+const RUNTIMES: Array<{ id: RuntimeId; label: string; icon: typeof Bot; builtIn?: boolean }> = [
   { id: "claude", label: "Claude Code", icon: Bot },
   { id: "codex", label: "Codex", icon: TerminalSquare },
   { id: "opencode", label: "OpenCode", icon: Braces },
   { id: "pi", label: "Pi", icon: CircleHelp },
+  { id: "pi-builtin", label: "Pi Agent（内置）", icon: CircleHelp, builtIn: true },
 ];
 
 type SetupSnapshot = {
@@ -199,6 +200,7 @@ export function RuntimeSettings({ api }: { api: Api }) {
   };
 
   const currentMeta = RUNTIMES.find((item) => item.id === selected)!;
+  const currentIsBuiltIn = currentMeta.builtIn === true;
   const currentProfile = profiles[selected];
   const currentSetup = setups[selected];
   const compatibleModels = useMemo(
@@ -286,7 +288,9 @@ export function RuntimeSettings({ api }: { api: Api }) {
                   : "安装和账号状态已检查，可以继续选择默认模型。"}</p>
             </div>
             <div className="runtime-overview__actions">
-              {currentSetup?.installation.state === "not_installed" ? (
+              {currentIsBuiltIn ? (
+                <span className="settings-inline-note">随应用内置，无需安装、登录或检查。</span>
+              ) : currentSetup?.installation.state === "not_installed" ? (
                 <button className="settings-button settings-button--primary" type="button"
                   disabled={!desktop || Boolean(busy)}
                   onClick={() => void changeManagedInstall(selected)}>
@@ -299,7 +303,7 @@ export function RuntimeSettings({ api }: { api: Api }) {
                   {busy === `probe:${selected}` ? "检查中…" : "重新检查"}
                 </button>
               )}
-              {currentSetup?.account.state !== "ready" && currentSetup?.installation.state === "installed" ? (
+              {!currentIsBuiltIn && currentSetup?.account.state !== "ready" && currentSetup?.installation.state === "installed" ? (
                 <button className="settings-button settings-button--secondary" type="button"
                   onClick={() => void copyLoginCommand(currentSetup.account.loginCommand)}>
                   <Copy size={16} />复制登录命令

--- a/web/src/views/model-settings/modelSettings.css
+++ b/web/src/views/model-settings/modelSettings.css
@@ -458,6 +458,16 @@
 
 .settings-confirm-remove p { margin: 0 0 10px; color: #7e3933; font-size: 13px; line-height: 1.5; }
 
+.pi-import-summary { margin: 0 15px 15px; display: grid; gap: 10px; font-size: 13px; }
+.pi-import-summary p { margin: 0; }
+.pi-import-summary ul { margin: 0; padding-left: 18px; display: grid; gap: 4px; }
+.pi-import-summary .pi-import-warnings { color: #8a5a12; }
+.pi-import-summary .settings-actions { margin-top: 4px; }
+
+.provider-dialog-pi-preset { display: grid; gap: 10px; border: 1px solid var(--settings-border); border-radius: 10px; padding: 12px; background: #fafafa; }
+.provider-dialog-pi-preset .settings-field--row { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 8px; align-items: center; }
+.provider-dialog-pi-preset .provider-dialog-hint { margin: 0; color: var(--settings-muted); font-size: 12px; }
+
 .settings-workbench--providers { min-height: 560px; }
 
 .settings-page-heading--models { margin-bottom: 2px; }


### PR DESCRIPTION
- 新增随装内置的 pi-builtin 运行时：打包锁定版 @earendil-works/pi-agent-core + pi-coding-agent@0.84.2 的官方 CLI 入口为 pi-agent-helper，与外部 pi 复用同一 JSONL RPC 协议，无需本机安装任何 Agent CLI；PiRuntimeConfigCompiler 以每会话私有配置根、离线模型运行时、 禁用扩展/技能/模板/主题/上下文文件的方式内置，权限面与既有外部 Pi 对齐
- 模型设置接入 Pi 官方预设（pi-ai 官方 provider 目录：DeepSeek/OpenAI/ Anthropic 等 30+ 家）与本地 Pi 配置导入（只读导入 ~/.pi/agent 的 models.json/auth.json，含凭据优先级 pi_cli_auth/kith_secret/env_ref/keyless 与安全边界，不复用 !command/复合插值/危险 env/symlink）
- 首次进入 Home 弹窗三步引导创建第一个 Agent（选运行时 → 配置模型 → 创建），app.db v13 记录 agent_onboarding_completed_at 一次性门控； Members/Chat 创建弹窗复用同一 AgentCreationWizard（模式区分 onboarding/create）
- 决策 41 记入 docs/decisions.md；app.db v14 为既有模型配置回填 pi-builtin 兼容键；Desktop 构建打包 helper 与主题资产并做 RPC 冒烟验证

<!-- PR 标题格式：<类型>(<模块>): <中文摘要>；模块可省略。 -->

## Summary

<!-- 1-3 bullets describing what this PR does and why. -->

-

## Motivation / linked issue

<!-- Closes #N / Relates to #N / Standalone improvement -->

## Changes

<!-- List the files changed and why. Keep the diff surgical. -->

## Test plan and evidence

<!-- Paste real output or observations, not only an expected result.

Examples:
- Domain/API changes: focused test plus `pnpm test --integration`
- Frontend changes: browser screenshots or interaction notes from a running app
- Desktop/runtime changes: `pnpm run desktop:dev` or packaged smoke evidence
- Packaging changes: `pnpm run desktop:pack` and, when relevant, `pnpm run desktop:dist`
-->

```text
# paste evidence here
```

## Documentation sync

Check the applicable items. The source of truth is `AGENTS.md` and `docs/progress.md`.

- [ ] Commands or scripts changed -> `docs/dev-commands.md` updated; `README.md` and `AGENTS.md` checked
- [ ] Architecture, API, data model, or guard changed -> `docs/kith-space/architecture-proposal.md` updated
- [ ] UI information architecture changed -> `docs/kith-space/ui-direction.md` updated
- [ ] Product or architecture decision changed -> `docs/decisions.md` updated; `docs/vision.md` / `docs/roadmap.md` checked
- [ ] Terminology changed -> `docs/glossary.md` updated
- [ ] Stage progress changed -> `README.md`, `docs/progress.md`, and `docs/roadmap.md` updated
- [ ] No documentation change is needed (explain why below)

**Documentation note:**

## Verification bar

- [ ] `pnpm run typecheck`
- [ ] `pnpm test --unit`
- [ ] `pnpm test --integration`
- [ ] `pnpm run desktop:bundle`
- [ ] Windows / macOS / Linux 的影响与验证结果已分别说明；未运行的平台已写明 CI、真实 smoke 或待办清单
- [ ] 平台条件 `skip` 只记为未覆盖缺口，没有表述成该平台已通过
- [ ] Relevant real-run, browser, or packaged smoke evidence is included above
- [ ] Anything not verified is listed below

**Not verified / skipped:**
